### PR TITLE
fix diagnosis invoke scan route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -943,12 +943,12 @@ delete-jira_setting:
 		--data '{"project_id":1001, "jira_setting_id":1003}' \
 		'http://localhost:8000/api/v1/diagnosis/delete-jira-setting/'
 
-.PHONY: start-diagnosis
-start-diagnosis:
+.PHONY: invoke-diagnosis-scan
+invoke-diagnosis-scan:
 	curl -is -XPOST \
 		--header 'x-amzn-oidc-identity: alice' \
 		--header 'X-XSRF-TOKEN: xxxxxxxxx' \
 		--header 'Cookie: XSRF-TOKEN=xxxxxxxxx;' \
 		--header 'Content-Type: application/json' \
 		--data '{"project_id":1001, "jira_setting_id":1001}' \
-		'http://localhost:8000/api/v1/diagnosis/start-diagnosis/'
+		'http://localhost:8000/api/v1/diagnosis/invoke-scan/'

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/CyberAgent/mimosa-core/proto/finding v0.0.0-20201028054340-f4dee5a77a75
 	github.com/CyberAgent/mimosa-core/proto/iam v0.0.0-20201028054340-f4dee5a77a75
 	github.com/CyberAgent/mimosa-core/proto/project v0.0.0-20201028054340-f4dee5a77a75
-	github.com/CyberAgent/mimosa-diagnosis/proto/diagnosis v0.0.0-20201019144846-94a28c6be318
+	github.com/CyberAgent/mimosa-diagnosis/proto/diagnosis v0.0.0-20201102104958-713d5ff0f488
 	github.com/CyberAgent/mimosa-osint/proto/osint v0.0.0-20201102010932-4bbc843802a4
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/CyberAgent/mimosa-core/proto/project v0.0.0-20201028054340-f4dee5a77a
 github.com/CyberAgent/mimosa-core/proto/project v0.0.0-20201028054340-f4dee5a77a75/go.mod h1:aLR5wwhPFyT4saOfd8UzEq8GtrVz82KBTDwT47Eic7Q=
 github.com/CyberAgent/mimosa-diagnosis/proto/diagnosis v0.0.0-20201019144846-94a28c6be318 h1:5LEFYNWKTpXRuHB6kBHreFWvsQGL0ZdibKyi02vnRew=
 github.com/CyberAgent/mimosa-diagnosis/proto/diagnosis v0.0.0-20201019144846-94a28c6be318/go.mod h1:xNsOp4oUyWK0o9iTwKIDPp/zMI7KjCahu24CEBWBWTk=
+github.com/CyberAgent/mimosa-diagnosis/proto/diagnosis v0.0.0-20201102104958-713d5ff0f488 h1:1rnZtZb0h9czSELbrJZmAXjOCppo2jBgmm0byF6jWRU=
+github.com/CyberAgent/mimosa-diagnosis/proto/diagnosis v0.0.0-20201102104958-713d5ff0f488/go.mod h1:xNsOp4oUyWK0o9iTwKIDPp/zMI7KjCahu24CEBWBWTk=
 github.com/CyberAgent/mimosa-osint/proto/osint v0.0.0-20201029135302-1dc15b2b2c2b h1:7zfQSzwonZlm5PNcnOv+9CK9oJykRvMBwK4I7WV+mbs=
 github.com/CyberAgent/mimosa-osint/proto/osint v0.0.0-20201029135302-1dc15b2b2c2b/go.mod h1:EgQkstmP7LtF6VEc+BL1HNB7DJyj0YbgFu1gdvVhG4I=
 github.com/CyberAgent/mimosa-osint/proto/osint v0.0.0-20201102010932-4bbc843802a4 h1:YSwdiCXne0zZgmY9KetDttyFTLS1rvB+5XyhUckYdIM=

--- a/router.go
+++ b/router.go
@@ -189,7 +189,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Get("/get-jira-setting", svc.getJiraSettingHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))
-					r.Post("/start-diagnosis", svc.startDiagnosisHandler)
+					r.Post("/invoke-scan", svc.invokeDiagnosisScanHandler)
 				})
 			})
 			r.Group(func(r chi.Router) {

--- a/service_diagnosis.go
+++ b/service_diagnosis.go
@@ -126,14 +126,14 @@ func (g *gatewayService) deleteJiraSettingHandler(w http.ResponseWriter, r *http
 	writeResponse(w, http.StatusOK, map[string]interface{}{successJSONKey: resp})
 }
 
-func (g *gatewayService) startDiagnosisHandler(w http.ResponseWriter, r *http.Request) {
-	req := &diagnosis.StartDiagnosisRequest{}
+func (g *gatewayService) invokeDiagnosisScanHandler(w http.ResponseWriter, r *http.Request) {
+	req := &diagnosis.InvokeScanRequest{}
 	bind(req, r)
 	if err := req.Validate(); err != nil {
 		writeResponse(w, http.StatusBadRequest, map[string]interface{}{errorJSONKey: err.Error()})
 		return
 	}
-	resp, err := g.diagnosisClient.StartDiagnosis(r.Context(), req)
+	resp, err := g.diagnosisClient.InvokeScan(r.Context(), req)
 	if err != nil {
 		writeResponse(w, http.StatusInternalServerError, map[string]interface{}{errorJSONKey: err.Error()})
 		return

--- a/service_diagnosis_test.go
+++ b/service_diagnosis_test.go
@@ -493,7 +493,7 @@ func TestDeleteJiraSettingHandler(t *testing.T) {
 	}
 }
 
-func TestStartDiagnosisHandler(t *testing.T) {
+func TestInvokeDiagnosisScanHandler(t *testing.T) {
 	diagnosisMock := &mockDiagnosisClient{}
 	svc := gatewayService{
 		diagnosisClient: diagnosisMock,
@@ -501,14 +501,14 @@ func TestStartDiagnosisHandler(t *testing.T) {
 	cases := []struct {
 		name       string
 		input      string
-		mockResp   *diagnosis.StartDiagnosisResponse
+		mockResp   *diagnosis.InvokeScanResponse
 		mockErr    error
 		wantStatus int
 	}{
 		{
 			name:       "OK",
 			input:      `{"project_id": 1, "jira_setting_id":1}`,
-			mockResp:   &diagnosis.StartDiagnosisResponse{},
+			mockResp:   &diagnosis.InvokeScanResponse{},
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -526,13 +526,13 @@ func TestStartDiagnosisHandler(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.mockResp != nil || c.mockErr != nil {
-				diagnosisMock.On("StartDiagnosis").Return(c.mockResp, c.mockErr).Once()
+				diagnosisMock.On("InvokeScan").Return(c.mockResp, c.mockErr).Once()
 			}
 			// Invoke HTTP Request
 			rec := httptest.NewRecorder()
-			req, _ := http.NewRequest(http.MethodPost, "/api/v1/diagnosis/start-diagnosis/", strings.NewReader(c.input))
+			req, _ := http.NewRequest(http.MethodPost, "/api/v1/diagnosis/invoke-scan/", strings.NewReader(c.input))
 			req.Header.Add("Content-Type", "application/json")
-			svc.startDiagnosisHandler(rec, req)
+			svc.invokeDiagnosisScanHandler(rec, req)
 			// Check Response
 			if c.wantStatus != rec.Code {
 				t.Fatalf("Unexpected HTTP status code: want=%+v, got=%+v", c.wantStatus, rec.Code)
@@ -591,7 +591,11 @@ func (m *mockDiagnosisClient) DeleteJiraSetting(context.Context, *diagnosis.Dele
 	args := m.Called()
 	return args.Get(0).(*empty.Empty), args.Error(1)
 }
-func (m *mockDiagnosisClient) StartDiagnosis(context.Context, *diagnosis.StartDiagnosisRequest, ...grpc.CallOption) (*diagnosis.StartDiagnosisResponse, error) {
+func (m *mockDiagnosisClient) InvokeScan(context.Context, *diagnosis.InvokeScanRequest, ...grpc.CallOption) (*diagnosis.InvokeScanResponse, error) {
 	args := m.Called()
-	return args.Get(0).(*diagnosis.StartDiagnosisResponse), args.Error(1)
+	return args.Get(0).(*diagnosis.InvokeScanResponse), args.Error(1)
+}
+func (m *mockDiagnosisClient) InvokeScanAll(context.Context, *empty.Empty, ...grpc.CallOption) (*empty.Empty, error) {
+	args := m.Called()
+	return args.Get(0).(*empty.Empty), args.Error(1)
 }


### PR DESCRIPTION
invoke-scanのパスをAWS、OSINTと同様のinvoke-scanに変更します