### PR TITLE
fix router

### DIFF
--- a/router.go
+++ b/router.go
@@ -205,8 +205,11 @@ func newRouter(svc *gatewayService) *chi.Mux {
 
 		r.Route("/code", func(r chi.Router) {
 			r.Group(func(r chi.Router) {
-				r.Use(svc.authzWithProject)
+				// project any
 				r.Get("/list-datasource", svc.listCodeDataSourceHandler)
+			})
+			r.Group(func(r chi.Router) {
+				r.Use(svc.authzWithProject)
 				r.Get("/list-gitleaks", svc.listGitleaksHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))


### PR DESCRIPTION
codeサービスで一部、共通のマスタ取得APIのものがあったのでプロジェクトIDの認可制御を外す修正です