### PR TITLE
panic時のアクセスログを修正

### DIFF
--- a/router.go
+++ b/router.go
@@ -15,8 +15,8 @@ func newRouter(svc *gatewayService) *chi.Mux {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
-	r.Use(middleware.Recoverer)
 	r.Use(httpLogger)
+	r.Use(middleware.Recoverer)
 	r.Use(middleware.StripSlashes)
 	r.Use(svc.authn)
 


### PR DESCRIPTION
panic発生時に、ユーザに返すレスポンスとアクセスログのステータスコードが異なる不具合を修正

resolve #54 