### PR TITLE
fix: auto-provisioning handling when user could not create user data …

### DIFF
--- a/service_iam.go
+++ b/service_iam.go
@@ -55,7 +55,7 @@ func (g *gatewayService) isAdminHandler(w http.ResponseWriter, r *http.Request) 
 }
 
 func (g *gatewayService) putUserHandler(w http.ResponseWriter, r *http.Request) {
-	user, err := getRequestUser(r)
+	user, err := getRequestUserSub(r)
 	if err != nil {
 		writeResponse(w, http.StatusUnauthorized, map[string]interface{}{errorJSONKey: errors.New("InvalidUser")})
 	}


### PR DESCRIPTION
オートプロビジョニングに失敗した場合にユーザが手動でユーザ作成するオペレーションを想定していたが一律エラーを返してしまっていたのでそのバグ修正です（ユーザ側が何もできない状態になってしまっていた）