### PR TITLE
Improve error handling

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -22,25 +23,25 @@ func encodeAccessToken(projectID, accessTokenID uint32, plainText string) string
 }
 
 // decodeAccessToken is decoding AccessToken, and return access_token_id, plain_text. Format: urlEncode({project_id}@{access_token_id}@{plain_text})
-func decodeAccessToken(ctx context.Context, accessToken string) (projectID, accessTokenID uint32, plainText string) {
+func decodeAccessToken(ctx context.Context, accessToken string) (projectID, accessTokenID uint32, plainText string, err error) {
 	tokenBody, err := base64.RawURLEncoding.DecodeString(accessToken)
 	if err != nil {
 		appLogger.Warnf(ctx, "Failed to decode access token, err=%+v", err)
-		return 0, 0, ""
+		return 0, 0, "", err
 	}
 	parts := strings.SplitN(string(tokenBody), "@", 3)
 	if len(parts) != 3 {
-		return 0, 0, ""
+		return 0, 0, "", errors.New("invalid token, token must contain three values")
 	}
 	pID, err := strconv.ParseUint(parts[0], 10, 32)
 	if err != nil {
 		appLogger.Warnf(ctx, "Failed to parse project_id, id=%s, err=%+v", parts[0], err)
-		return 0, 0, ""
+		return 0, 0, "", err
 	}
 	aID, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {
 		appLogger.Warnf(ctx, "Failed to parse access_token_id, id=%s, err=%+v", parts[0], err)
-		return 0, 0, ""
+		return 0, 0, "", err
 	}
-	return uint32(pID), uint32(aID), parts[2]
+	return uint32(pID), uint32(aID), parts[2], nil
 }

--- a/access_token_test.go
+++ b/access_token_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEncodeAccessToken(t *testing.T) {
@@ -39,6 +41,7 @@ func TestDecodeAccessToken(t *testing.T) {
 		wantProjectID     uint32
 		wantAccessTokenID uint32
 		wantPlainText     string
+		wantErr           bool
 	}{
 		{
 			name:              "OK 1",
@@ -55,28 +58,28 @@ func TestDecodeAccessToken(t *testing.T) {
 			wantPlainText:     "333@plain_text",
 		},
 		{
-			name:              "Blank",
-			input:             "",
-			wantAccessTokenID: 0,
-			wantPlainText:     "",
+			name:    "Blank",
+			input:   "",
+			wantErr: true,
 		},
 		{
-			name:              "Invalid token",
-			input:             "xxx",
-			wantAccessTokenID: 0,
-			wantPlainText:     "",
+			name:    "Invalid token",
+			input:   "xxx",
+			wantErr: true,
 		},
 		{
-			name:              "Invalid format",
-			input:             base64.RawURLEncoding.EncodeToString([]byte("1001/plain_text")), // `/` char is invalid
-			wantAccessTokenID: 0,
-			wantPlainText:     "",
+			name:    "Invalid format",
+			input:   base64.RawURLEncoding.EncodeToString([]byte("1001/plain_text")), // `/` char is invalid
+			wantErr: true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
-			gotProjectID, gotAccessTokenID, gotPlainText := decodeAccessToken(ctx, c.input)
+			gotProjectID, gotAccessTokenID, gotPlainText, err := decodeAccessToken(ctx, c.input)
+			if c.wantErr {
+				assert.Error(t, err)
+			}
 			if gotProjectID != c.wantProjectID {
 				t.Fatalf("Unexpected ProjectID. want=%d, got=%d", c.wantProjectID, gotProjectID)
 			}

--- a/authorizer.go
+++ b/authorizer.go
@@ -192,11 +192,12 @@ func (g *gatewayService) authzWithProject(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		buf, err := ioutil.ReadAll(r.Body)
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
 		if err != nil {
+			appLogger.Errorf(ctx, "failed to read body, err=%+v", err)
 			http.Error(w, "Could not read body", http.StatusInternalServerError)
 			return
 		}
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
 
 		u, err := getRequestUser(r)
 		if err != nil {
@@ -228,11 +229,13 @@ func (g *gatewayService) authzOnlyAdmin(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		buf, err := ioutil.ReadAll(r.Body)
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
 		if err != nil {
+			appLogger.Errorf(ctx, "failed to read body, err=%+v", err)
 			http.Error(w, "Could not read body", http.StatusInternalServerError)
 			return
 		}
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+
 		u, err := getRequestUser(r)
 		if err != nil {
 			appLogger.Infof(ctx, "Unauthenticated: %+v", err)

--- a/authorizer.go
+++ b/authorizer.go
@@ -172,6 +172,7 @@ func (g *gatewayService) authnToken(next http.Handler) http.Handler {
 			PlainTextToken: plainTextToken,
 		})
 		if err != nil {
+			// TODO 認証でエラーになった後に継続する後続の処理があるか確認、できる限りすぐに403などを返したい
 			appLogger.Errorf(ctx, "Failed to AuthenticateAccessToken API, err=%+v", err)
 			next.ServeHTTP(w, r)
 			return

--- a/authorizer.go
+++ b/authorizer.go
@@ -193,7 +193,7 @@ func (g *gatewayService) authzWithProject(next http.Handler) http.Handler {
 		ctx := r.Context()
 		buf, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			appLogger.Errorf(ctx, "failed to read body, err=%+v", err)
+			appLogger.Errorf(ctx, "Failed to read body, err=%+v", err)
 			http.Error(w, "Could not read body", http.StatusInternalServerError)
 			return
 		}
@@ -230,7 +230,7 @@ func (g *gatewayService) authzOnlyAdmin(next http.Handler) http.Handler {
 		ctx := r.Context()
 		buf, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			appLogger.Errorf(ctx, "failed to read body, err=%+v", err)
+			appLogger.Errorf(ctx, "Failed to read body, err=%+v", err)
 			http.Error(w, "Could not read body", http.StatusInternalServerError)
 			return
 		}

--- a/authorizer.go
+++ b/authorizer.go
@@ -160,8 +160,9 @@ func (g *gatewayService) authnToken(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		projectID, accessTokenID, plainTextToken := decodeAccessToken(ctx, tokenBody)
-		if zero.IsZeroVal(accessTokenID) || zero.IsZeroVal(plainTextToken) {
+		projectID, accessTokenID, plainTextToken, err := decodeAccessToken(ctx, tokenBody)
+		if err != nil {
+			// TODO アクセストークンが不要な後続処理があるかを確認、不要な場合はすぐに403などを返したい
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	tracer.Start(tc)
 	defer tracer.Stop()
 
-	svc, err := newGatewayService(&appConfig)
+	svc, err := newGatewayService(ctx, &appConfig)
 	if err != nil {
 		appLogger.Fatal(ctx, err.Error())
 	}

--- a/service.go
+++ b/service.go
@@ -48,23 +48,25 @@ type gatewayService struct {
 	googleClient      google.GoogleServiceClient
 }
 
-func newGatewayService(conf *AppConfig) (*gatewayService, error) {
+func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
 	if conf.Debug {
 		appLogger.Level(logging.DebugLevel)
 	}
 
-	ctx := context.Background()
 	coreConn, err := getGRPCConn(ctx, conf.CoreAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to get grpc connection to core service, err=%+v", err)
+		appLogger.Errorf(ctx, "Failed to get grpc connection to core service, err=%+v", err)
+		return nil, err
 	}
 	datasourceConn, err := getGRPCConn(ctx, conf.DataSourceAPISvcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to get grpc connection to datasource api service, err=%+v", err)
+		appLogger.Errorf(ctx, "Failed to get grpc connection to datasource api service, err=%+v", err)
+		return nil, err
 	}
 	awsActivityConn, err := getGRPCConn(ctx, conf.AWSActivitySvcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "failed to get grpc connection to aws activity service, err=%+v", err)
+		appLogger.Errorf(ctx, "Failed to get grpc connection to aws activity service, err=%+v", err)
+		return nil, err
 	}
 	return &gatewayService{
 		envName:           conf.EnvName,

--- a/service.go
+++ b/service.go
@@ -116,5 +116,8 @@ func writeResponse(ctx context.Context, w http.ResponseWriter, status int, body 
 	}
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_, _ = w.Write(buf)
+	_, err = w.Write(buf)
+	if err != nil {
+		appLogger.Errorf(ctx, "failed to write response, err=%+v", err)
+	}
 }


### PR DESCRIPTION
middlewareのエラーハンドリング改善のうち、影響範囲が小さいものの対応。
他のmiddlewareの処理に影響するものは、middleware全体の責務の整理が必要なので別PRで対応するためTODOコメントを残すだけにしています。