### PR TITLE
Fix duplicate next handler call

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -180,12 +180,8 @@ func (g *gatewayService) authnToken(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		appLogger.Debugf(ctx, "1st authnToken")
 		next.ServeHTTP(w, r.WithContext(
 			context.WithValue(ctx, userKey, &requestUser{accessTokenID: accessTokenID})))
-
-		appLogger.Debugf(ctx, "2nd authnToken")
-		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
アクセストークンを使用したAPI呼び出しの際に、後続のミドルウェアを重複して呼び出していた不具合を修正。
手元で確認したところ、業務ロジック（httpハンドラ）は一度しか呼ばれていなかったので、データが二重に登録される、などの状態にはなっていない。