### PR TITLE
Fix panic when using unregistered access token

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -175,7 +175,7 @@ func (g *gatewayService) authnToken(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if zero.IsZeroVal(resp.AccessToken.AccessTokenId) {
+		if resp.AccessToken == nil || resp.AccessToken.AccessTokenId == 0 {
 			appLogger.Error(ctx, "Failed to get AccessTokenId")
 			next.ServeHTTP(w, r)
 			return


### PR DESCRIPTION
RISKENに登録されていないaccess tokenを使用してAPIアクセスをした場合、panicになるのを修正しました。
テストは、ミドルウェアの責務配置を見直すタイミングで追加する予定です。