### PR TITLE
add provisioning

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -24,7 +24,7 @@ type requestUser struct {
 	// human access
 	sub    string
 	userID uint32
-	Name   string
+	name   string
 
 	// program access
 	accessTokenID uint32
@@ -107,8 +107,8 @@ func (g *gatewayService) UpdateUserFromIdp(next http.Handler) http.Handler {
 			http.Error(w, "Unauthenticated", http.StatusUnauthorized)
 			return
 		}
-		if u.Name != "" {
-			putUserRequest.User.Name = u.Name
+		if u.name != "" {
+			putUserRequest.User.Name = u.name
 		}
 		putResp, err := g.iamClient.PutUser(ctx, putUserRequest)
 		if err != nil {
@@ -144,7 +144,7 @@ func (g *gatewayService) authn(next http.Handler) http.Handler {
 		}
 		if resp != nil && resp.User != nil {
 			next.ServeHTTP(w, r.WithContext(
-				context.WithValue(ctx, userKey, &requestUser{sub: sub, userID: resp.User.UserId, Name: resp.User.Name})))
+				context.WithValue(ctx, userKey, &requestUser{sub: sub, userID: resp.User.UserId, name: resp.User.Name})))
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/authorizer.go
+++ b/authorizer.go
@@ -3,19 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/ca-risken/core/proto/iam"
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/vikyd/zero"
 )
 
@@ -70,8 +65,7 @@ func signinHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Authentication for human access
-func (g *gatewayService) authn(next http.Handler) http.Handler {
+func (g *gatewayService) Provisioning(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		sub := r.Header.Get(g.uidHeader)
@@ -79,43 +73,45 @@ func (g *gatewayService) authn(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		appLogger.Debugf(ctx, "sub: %s", sub)
-		appLogger.Debugf(ctx, "oidcData: %+v", r.Header.Get(g.oidcDataHeader))
-		resp, err := g.iamClient.GetUser(ctx, &iam.GetUserRequest{Sub: sub})
+		oidcData := r.Header.Get(g.oidcDataHeader) // r.Header.Get("X-Amzn-Oidc-Data")
+		claims, err := g.claimsClient.getClaims(ctx, oidcData)
+		appLogger.Debugf(ctx, "claims: %+v", claims)
+		if err != nil {
+			appLogger.Warnf(ctx, "Failed to validate id token, err=%+v", err)
+			http.Error(w, "Failed to validate id token", http.StatusForbidden)
+			return
+		}
+		userIdpKey := g.claimsClient.getUserIdpKey(claims)
+		if userIdpKey == "" {
+			appLogger.Warnf(ctx, "UserIdpKey is not found in token, err=%+v", err)
+			http.Error(w, "UserIdpKey is not found in token", http.StatusForbidden)
+			return
+		}
+		userName := g.claimsClient.getUserName(claims)
+		if userName == "" {
+			userName = userIdpKey
+		}
+		putUserRequest := &iam.PutUserRequest{
+			User: &iam.UserForUpsert{
+				Sub:        sub,
+				Name:       userName,
+				UserIdpKey: userIdpKey,
+				Activated:  true,
+			},
+		}
+		// 既存のユーザーであれば、手動でNameを変更している可能性があるので、保存されているユーザー名を使用する
+		getResp, err := g.iamClient.GetUser(ctx, &iam.GetUserRequest{
+			Sub: sub,
+		})
 		if err != nil {
 			appLogger.Warnf(ctx, "Failed to GetUser request, err=%+v", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
-		if resp != nil && resp.User != nil {
-			next.ServeHTTP(w, r.WithContext(
-				context.WithValue(ctx, userKey, &requestUser{sub: sub, userID: resp.User.UserId})))
-			return
+		if getResp != nil && getResp.User != nil {
+			putUserRequest.User.Name = getResp.User.Name
 		}
-		// Try AUTO PROVISIONING
-		oidcData := r.Header.Get(g.oidcDataHeader) // r.Header.Get("X-Amzn-Oidc-Data")
-		if g.VerifyIDToken {
-			err = g.verifyTokenForALB(ctx, oidcData)
-			if err != nil {
-				appLogger.Warnf(ctx, "Failed to validate id token, err=%+v", err)
-				http.Error(w, "Internal server error", http.StatusForbidden)
-				return
-			}
-		}
-		userName, err := g.getUserName(oidcData)
-		if err != nil || zero.IsZeroVal(userName) {
-			appLogger.Warnf(ctx, "Failed to get username from oidc data, err=%+v", err)
-			next.ServeHTTP(w, r.WithContext(
-				context.WithValue(ctx, userKey, &requestUser{sub: sub})))
-			return
-		}
-		putResp, err := g.iamClient.PutUser(ctx, &iam.PutUserRequest{
-			User: &iam.UserForUpsert{
-				Sub:       sub,
-				Name:      userName,
-				Activated: true,
-			},
-		})
+		putResp, err := g.iamClient.PutUser(ctx, putUserRequest)
 		if err != nil {
 			appLogger.Warnf(ctx, "Failed to PutUser request, err=%+v", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -131,33 +127,30 @@ func (g *gatewayService) authn(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-type userCalim struct {
-	Sub      string `json:"sub"`
-	Username string `json:"username"`
-}
-
-func (g *gatewayService) getUserName(jwt string) (string, error) {
-	parts := strings.Split(jwt, ".")
-	if len(parts) != 3 {
-		return "", errors.New("Invalid JWT string pattern")
-	}
-	// Decode JWT
-	claimBytes, err := base64.StdEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", err
-	}
-	var user userCalim
-	if err := json.NewDecoder(bytes.NewBuffer(claimBytes)).Decode(&user); err != nil {
-		return "", err
-	}
-	username := user.Username
-	for _, idp := range g.idpProviderName {
-		if strings.HasPrefix(strings.ToLower(username), strings.ToLower(idp)+"_") {
-			username = strings.Replace(username, idp+"_", "", 1)
-			break
+// Authentication for human access
+func (g *gatewayService) authn(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		sub := r.Header.Get(g.uidHeader)
+		if sub == "" {
+			next.ServeHTTP(w, r)
+			return
 		}
+		appLogger.Debugf(ctx, "sub: %s", sub)
+		resp, err := g.iamClient.GetUser(ctx, &iam.GetUserRequest{Sub: sub})
+		if err != nil {
+			appLogger.Warnf(ctx, "Failed to GetUser request, err=%+v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		if resp != nil && resp.User != nil {
+			next.ServeHTTP(w, r.WithContext(
+				context.WithValue(ctx, userKey, &requestUser{sub: sub, userID: resp.User.UserId})))
+			return
+		}
+		next.ServeHTTP(w, r)
 	}
-	return username, nil
+	return http.HandlerFunc(fn)
 }
 
 // Authentication for programable API access
@@ -279,56 +272,6 @@ func (g *gatewayService) verifyCSRF(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)
-}
-
-const (
-	PublicKeyURLTemplate = "https://public-keys.auth.elb.%s.amazonaws.com/%s"
-)
-
-func (g *gatewayService) verifyTokenForALB(ctx context.Context, tokenString string) error {
-	jwt.DecodePaddingAllowed = true
-	_, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-		kid, ok := token.Header["kid"].(string)
-		if !ok {
-			return nil, errors.New("kid is not found in jwt header")
-		}
-		keyURL := fmt.Sprintf(PublicKeyURLTemplate, g.Region, kid)
-		key, err := g.fetchALBPublicKey(ctx, keyURL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get public key, err: %w", err)
-		}
-		return key, nil
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (g *gatewayService) fetchALBPublicKey(ctx context.Context, keyURL string) (*ecdsa.PublicKey, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, keyURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to new GET request for %s, err: %w", keyURL, err)
-	}
-	client := http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get public key from %s, err: %w", keyURL, err)
-	}
-	defer resp.Body.Close()
-	pem, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body from %s, err: %w", keyURL, err)
-	}
-	publicKey, err := jwt.ParseECPublicKeyFromPEM(pem)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key from %s, err: %w", keyURL, err)
-	}
-
-	return publicKey, nil
 }
 
 func isHumanAccess(u *requestUser) bool {

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -429,7 +429,7 @@ func setContextValue(next http.Handler) http.Handler {
 		userID, _ := strconv.Atoi(strUserID)
 		requestUser := &requestUser{
 			userID: uint32(userID),
-			Name:   name,
+			name:   name,
 		}
 		r = r.WithContext(context.WithValue(r.Context(), userKey, requestUser))
 		next.ServeHTTP(w, r)
@@ -506,7 +506,7 @@ func TestUpdateUserFromIdp(t *testing.T) {
 			requestUser: &requestUser{
 				sub:    "sub",
 				userID: 1,
-				Name:   "name",
+				name:   "name",
 			},
 			mockPutUserResp: &iam.PutUserResponse{},
 			userName:        "username",
@@ -555,7 +555,7 @@ func TestUpdateUserFromIdp(t *testing.T) {
 			requestUser: &requestUser{
 				sub:    "sub",
 				userID: 1,
-				Name:   "name",
+				name:   "name",
 			},
 			mockPutUserErr: errors.New("something error"),
 			wantStatusCode: http.StatusInternalServerError,
@@ -574,7 +574,7 @@ func TestUpdateUserFromIdp(t *testing.T) {
 			// テスト用に作成したmiddlewareでヘッダに挿入した値をcontextに注入します
 			if c.requestUser != nil {
 				req.Header.Set("test-requestUser-userID", fmt.Sprint(c.requestUser.userID))
-				req.Header.Set("test-requestUser-userName", c.requestUser.Name)
+				req.Header.Set("test-requestUser-userName", c.requestUser.name)
 			}
 			g.claimsClient = newMockClaimsClient(c.claims, c.userName, c.userIdpKey, c.mockClaimsErr)
 			res, err := client.Do(req)

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -411,7 +412,10 @@ func TestShouldVerifyCSRFTokenURI(t *testing.T) {
 
 func GetTestHandler() http.HandlerFunc {
 	fn := func(rw http.ResponseWriter, req *http.Request) {
-		rw.Write([]byte("OK"))
+		_, err := rw.Write([]byte("OK"))
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
 	}
 	return http.HandlerFunc(fn)
 }

--- a/claims.go
+++ b/claims.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type claimsClient struct {
+	region          string
+	userIdpKey      string
+	idpProviderName []string
+	verify          bool
+}
+
+type claimsInterface interface {
+	getClaims(ctx context.Context, tokenString string) (*jwt.MapClaims, error)
+	getUserName(claims *jwt.MapClaims) string
+	getUserIdpKey(claims *jwt.MapClaims) string
+}
+
+func newClaimsClient(region, userIdpKey string, idpProviderName []string, verify bool) *claimsClient {
+	return &claimsClient{
+		region:          region,
+		userIdpKey:      userIdpKey,
+		idpProviderName: idpProviderName,
+		verify:          verify,
+	}
+}
+
+func (c *claimsClient) getClaims(ctx context.Context, tokenString string) (*jwt.MapClaims, error) {
+	var claims *jwt.MapClaims
+	var err error
+	if c.verify {
+		claims, err = c.getClaimsForALB(ctx, tokenString)
+	} else {
+		claims, err = c.getClaimsWithoutVerify(tokenString)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+func (c *claimsClient) getClaimsForALB(ctx context.Context, tokenString string) (*jwt.MapClaims, error) {
+	jwt.DecodePaddingAllowed = true
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, errors.New("kid is not found in jwt header")
+		}
+		keyURL := fmt.Sprintf(PublicKeyURLTemplate, c.region, kid)
+		key, err := fetchALBPublicKey(ctx, keyURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get public key, err: %w", err)
+		}
+		return key, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return nil, errors.New("invalid token")
+	}
+	return &claims, nil
+}
+
+const (
+	PublicKeyURLTemplate = "https://public-keys.auth.elb.%s.amazonaws.com/%s"
+)
+
+func fetchALBPublicKey(ctx context.Context, keyURL string) (*ecdsa.PublicKey, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, keyURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to new GET request for %s, err: %w", keyURL, err)
+	}
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get public key from %s, err: %w", keyURL, err)
+	}
+	defer resp.Body.Close()
+	pem, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body from %s, err: %w", keyURL, err)
+	}
+	publicKey, err := jwt.ParseECPublicKeyFromPEM(pem)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key from %s, err: %w", keyURL, err)
+	}
+
+	return publicKey, nil
+}
+
+func (c *claimsClient) getClaimsWithoutVerify(tokenString string) (*jwt.MapClaims, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("invalid JWT string pattern")
+	}
+	// Decode JWT
+	claimBytes, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	var claims jwt.MapClaims
+	if err := json.NewDecoder(bytes.NewBuffer(claimBytes)).Decode(&claims); err != nil {
+		return nil, err
+	}
+	return &claims, nil
+}
+
+func (c *claimsClient) getUserName(claims *jwt.MapClaims) string {
+	value, ok := (*claims)["username"]
+	if !ok {
+		return ""
+	}
+	userName, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	for _, idp := range c.idpProviderName {
+		if strings.HasPrefix(strings.ToLower(userName), strings.ToLower(idp)+"_") {
+			userName = strings.Replace(userName, idp+"_", "", 1)
+			break
+		}
+	}
+	return userName
+}
+
+func (c *claimsClient) getUserIdpKey(claims *jwt.MapClaims) string {
+	value, ok := (*claims)[c.userIdpKey]
+	if !ok {
+		return ""
+	}
+	strValue, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strValue
+}

--- a/claims_test.go
+++ b/claims_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/jarcoal/httpmock"
+)
+
+func TestVerifyTokenForALB(t *testing.T) {
+	cases := []struct {
+		name         string
+		tokenString  string
+		keyURL       string
+		mockStatus   int
+		mockResponse string
+		mockErr      error
+		wantErr      bool
+	}{
+		{
+			name:        "NG alg is not ES256",
+			tokenString: "YWxnOmludmFsaWQgdHlwOkpXVAo.eyJmb28iOiJiYXIifQ.MEQCIHoSJnmGlPaVQDqacx_2XlXEhhqtWceVopjomc2PJLtdAiAUTeGPoNYxZw0z8mgOnnIcjoxRuNDVZvybRZF3wR1l8W",
+			wantErr:     true,
+		},
+		{
+			name:        "NG kid doesn't exist in JWT header",
+			tokenString: "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.MEQCIHoSJnmGlPaVQDqacx_2XlXEhhqtWceVopjomc2PJLtdAiAUTeGPoNYxZw0z8mgOnnIcjoxRuNDVZvybRZF3wR1l8W",
+			wantErr:     true,
+		},
+		{
+			name:        "NG fetch Public key error",
+			tokenString: "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImhvZ2UifQo.eyJmb28iOiJiYXIifQ.MEQCIHoSJnmGlPaVQDqacx_2XlXEhhqtWceVopjomc2PJLtdAiAUTeGPoNYxZw0z8mgOnnIcjoxRuNDVZvybRZF3wR1l8W",
+			keyURL:      "https://public-keys.auth.elb.ap-northeast-1.amazonaws.com/hoge",
+			mockErr:     errors.New("something error"),
+			wantErr:     true,
+		},
+		{
+			name:        "NG verify Error",
+			tokenString: "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImhvZ2UifQo.eyJmb28iOiJiYXIifQ.MEQCIHoSJnmGlPaVQDqacx_2XlXEhhqtWceVopjomc2PJLtdAiAUTeGPoNYxZw0z8mgOnnIcjoxRuNDVZvybRZF3wR1l8W",
+			keyURL:      "https://public-keys.auth.elb.ap-northeast-1.amazonaws.com/hoge",
+			mockStatus:  200,
+			mockResponse: `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYD54V/vp+54P9DXarYqx4MPcm+HK
+RIQzNasYSoRQHQ/6S6Ps8tpMcT+KvIIC8W/e9k0W7Cm72M1P9jU7SLf/vg==
+-----END PUBLIC KEY-----
+`,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.keyURL != "" {
+				httpmock.Activate()
+				defer httpmock.DeactivateAndReset()
+				if c.mockErr == nil {
+					httpmock.RegisterResponder("GET", c.keyURL,
+						httpmock.NewStringResponder(c.mockStatus, c.mockResponse))
+				} else {
+					httpmock.RegisterResponder("GET", c.keyURL,
+						func(req *http.Request) (*http.Response, error) {
+							return nil, c.mockErr
+						})
+				}
+			}
+			cli := claimsClient{
+				region: "ap-northeast-1",
+			}
+			_, err := cli.getClaimsForALB(context.Background(), c.tokenString)
+			if (c.wantErr && err == nil) || (!c.wantErr && err != nil) {
+				t.Fatalf("Unexpected error: wantErr=%t, err=%+v", c.wantErr, err)
+			}
+		})
+	}
+}
+func TestFetchPublicKey(t *testing.T) {
+	cases := []struct {
+		name         string
+		keyURL       string
+		mockStatus   int
+		mockResponse string
+		mockErr      error
+		want         *ecdsa.PublicKey
+		wantErr      bool
+	}{
+		{
+			name:       "OK",
+			keyURL:     "http://example.com/valid",
+			mockStatus: 200,
+			mockResponse: `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYD54V/vp+54P9DXarYqx4MPcm+HK
+RIQzNasYSoRQHQ/6S6Ps8tpMcT+KvIIC8W/e9k0W7Cm72M1P9jU7SLf/vg==
+-----END PUBLIC KEY-----
+`,
+			wantErr: false,
+		},
+		{
+			name:         "NG Parse Error",
+			keyURL:       "http://example.com/invalid",
+			mockStatus:   200,
+			mockResponse: `Invalid Key`,
+			wantErr:      true,
+		},
+		{
+			name:    "NG HTTP Error",
+			keyURL:  "http://example.com/error",
+			mockErr: errors.New("something error"),
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			if c.mockErr == nil {
+				httpmock.RegisterResponder("GET", c.keyURL,
+					httpmock.NewStringResponder(c.mockStatus, c.mockResponse))
+			} else {
+				httpmock.RegisterResponder("GET", c.keyURL,
+					func(req *http.Request) (*http.Response, error) {
+						return nil, c.mockErr
+					})
+			}
+			_, err := fetchALBPublicKey(context.Background(), c.keyURL)
+			if (c.wantErr && err == nil) || (!c.wantErr && err != nil) {
+				t.Fatalf("Unexpected error: wantErr=%t, err=%+v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestGetClaimsWithoutVerify(t *testing.T) {
+	cases := []struct {
+		name    string
+		token   string
+		want    *jwt.MapClaims
+		wantErr bool
+	}{
+		{
+			name:  "OK Get Claims",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0K.1EmGW2C02O8vcS_w4-OjOjHnegrYuBiBg3okk-WY_qI",
+			want: &jwt.MapClaims{
+				"sub": "test",
+			},
+		},
+		{
+			name:    "NG invalid string pattern",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIiLCJpYXQiOjE1MTYyMzkwMjJ9",
+			wantErr: true,
+		},
+		{
+			name:    "NG base64 decode error",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIiLCJpYXQiOjE1MTYyMzkwMjJ9###.3nBr2r_c2ukFrbhh_aomGSP4B9CCdtnwgcIlp2LN5GE",
+			wantErr: true,
+		},
+		{
+			name:    "NG jwt unmarshal error",
+			token:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.aG9nZWZ1Z2EK.3nBr2r_c2ukFrbhh_aomGSP4B9CCdtnwgcIlp2LN5GE",
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cli := claimsClient{}
+			got, err := cli.getClaimsWithoutVerify(c.token)
+			if (c.wantErr && err == nil) || (!c.wantErr && err != nil) {
+				t.Fatalf("Unexpected error: wantErr=%t, err=%+v", c.wantErr, err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected response. want=%+v, got=%+v", c.want, got)
+
+			}
+		})
+	}
+}
+
+func TestGetUserName(t *testing.T) {
+	cases := []struct {
+		name            string
+		token           *jwt.MapClaims
+		idpProviderName []string
+		want            string
+	}{
+		{
+			name: "OK Get UserName (Not Trim)",
+			token: &jwt.MapClaims{
+				"username": "value",
+			},
+			idpProviderName: []string{"IDP1", "IDP2"},
+			want:            "value",
+		},
+		{
+			name: "OK Get Attribute (Trim)",
+			token: &jwt.MapClaims{
+				"username": "IDP1_value",
+			},
+			idpProviderName: []string{"IDP1", "IDP2"},
+			want:            "value",
+		},
+		{
+			name: "OK Not Found username",
+			token: &jwt.MapClaims{
+				"field": "value",
+			},
+			idpProviderName: []string{"IDP1", "IDP2"},
+			want:            "",
+		},
+		{
+			name: "OK failed to convert username",
+			token: &jwt.MapClaims{
+				"username": nil,
+			},
+			idpProviderName: []string{"IDP1", "IDP2"},
+			want:            "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cli := claimsClient{
+				idpProviderName: c.idpProviderName,
+			}
+			got := cli.getUserName(c.token)
+			if got != c.want {
+				t.Fatalf("Unexpected response. want=%v, got=%v", c.want, got)
+			}
+		})
+	}
+}
+
+func TestGetUserIdpKey(t *testing.T) {
+	cases := []struct {
+		name   string
+		token  *jwt.MapClaims
+		idpKey string
+		want   string
+	}{
+		{
+			name: "OK Get value",
+			token: &jwt.MapClaims{
+				"key": "value",
+			},
+			idpKey: "key",
+			want:   "value",
+		},
+		{
+			name: "OK failed to convert user_idp_key",
+			token: &jwt.MapClaims{
+				"key": nil,
+			},
+			idpKey: "key",
+			want:   "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cli := claimsClient{
+				userIdpKey: c.idpKey,
+			}
+			got := cli.getUserIdpKey(c.token)
+			if got != c.want {
+				t.Fatalf("Unexpected response. want=%v, got=%v", c.want, got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220601065422-5b97bd6efc9b
-	github.com/ca-risken/core v0.4.2-0.20221114035311-c4b88fcc3162
+	github.com/ca-risken/core v0.4.2-0.20221201035140-276336d351a5
 	github.com/ca-risken/datasource-api v0.4.2-0.20221121055843-3dc9a448cda2
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
@@ -15,6 +15,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/schema v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/jarcoal/httpmock v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	github.com/vikyd/zero v0.0.0-20190921142904-0f738d0bc858
@@ -39,7 +40,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/google/pprof v0.0.0-20210423192551-a2663126120b // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/jarcoal/httpmock v1.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b h1:S
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220601065422-5b97bd6efc9b h1:qt68fmotTZgAFvjnP0DnAdusZwWdOTAlqErQEfgbyCg=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220601065422-5b97bd6efc9b/go.mod h1:PIXjETIPseBEB/OXp5Rxn8FFuRwfQjFZe1VN+0Skh2E=
-github.com/ca-risken/core v0.4.2-0.20221114035311-c4b88fcc3162 h1:suceXZrT0FaTVnFBYPc/2hpsfPZFRWp1Aoil8q5EYGo=
-github.com/ca-risken/core v0.4.2-0.20221114035311-c4b88fcc3162/go.mod h1:bbn0h9PJ2aQW9hGeRNja98Tx3vQQ5hDFWrCVkKgaR2w=
+github.com/ca-risken/core v0.4.2-0.20221201035140-276336d351a5 h1:ABBTjaCviqs4HecDeLkh1cG8bJ8T2+BozgYzE6pp2dE=
+github.com/ca-risken/core v0.4.2-0.20221201035140-276336d351a5/go.mod h1:imJ7Eut2LDOaG6i9VnbfxZdILA3bJorSQ/OGgt0VQJM=
 github.com/ca-risken/datasource-api v0.4.2-0.20221121055843-3dc9a448cda2 h1:oAPXtAYeRdYsAJkaeuuUN5dLCOWlV6rPXPGo1czQZRc=
 github.com/ca-risken/datasource-api v0.4.2-0.20221121055843-3dc9a448cda2/go.mod h1:XAUaKNB8N0+1DED5mVuq2ldzT4pZlLzIwCbTlr1QBwg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -506,6 +506,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maxatome/go-testdeep v1.11.0 h1:Tgh5efyCYyJFGUYiT0qxBSIDeXw0F5zSoatlou685kk=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type AppConfig struct {
 	OidcDataHeader     string   `required:"true" split_words:"true" default:"x-amzn-oidc-data"`
 	IdpProviderName    []string `required:"true" split_words:"true" default:"YOUR_IDP1,YOUR_IDP2"`
 	VerifyIDToken      bool     `split_words:"true" default:"false"`
+	UserIdpKey         string   `split_words:"true" default:"preferred_username"`
 	Region             string   `default:"ap-northeast-1"`
 
 	CoreAddr             string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`

--- a/router.go
+++ b/router.go
@@ -29,7 +29,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Route("/signin", func(r chi.Router) {
-			r.Use(svc.Provisioning)
+			r.Use(svc.UpdateUserFromIdp)
 			r.Get("/", signinHandler)
 		})
 

--- a/router.go
+++ b/router.go
@@ -28,7 +28,10 @@ func newRouter(svc *gatewayService) *chi.Mux {
 	r.NotFound(notFoundHandler)
 
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Get("/signin", signinHandler)
+		r.Route("/signin", func(r chi.Router) {
+			r.Use(svc.Provisioning)
+			r.Get("/", signinHandler)
+		})
 
 		r.Route("/finding", func(r chi.Router) {
 			r.Use(svc.authzWithProject)

--- a/service.go
+++ b/service.go
@@ -34,9 +34,6 @@ type gatewayService struct {
 	port            string
 	uidHeader       string
 	oidcDataHeader  string
-	idpProviderName []string
-	VerifyIDToken   bool
-	Region          string
 	findingClient   finding.FindingServiceClient
 	iamClient       iam.IAMServiceClient
 	projectClient   project.ProjectServiceClient
@@ -48,6 +45,7 @@ type gatewayService struct {
 	diagnosisClient diagnosis.DiagnosisServiceClient
 	codeClient      code.CodeServiceClient
 	googleClient    google.GoogleServiceClient
+	claimsClient    claimsInterface
 }
 
 func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
@@ -75,9 +73,6 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		port:            conf.Port,
 		uidHeader:       conf.UserIdentityHeader,
 		oidcDataHeader:  conf.OidcDataHeader,
-		idpProviderName: conf.IdpProviderName,
-		VerifyIDToken:   conf.VerifyIDToken,
-		Region:          conf.Region,
 		findingClient:   finding.NewFindingServiceClient(coreConn),
 		iamClient:       iam.NewIAMServiceClient(coreConn),
 		projectClient:   project.NewProjectServiceClient(coreConn),
@@ -89,6 +84,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		diagnosisClient: diagnosis.NewDiagnosisServiceClient(datasourceConn),
 		codeClient:      code.NewCodeServiceClient(datasourceConn),
 		googleClient:    google.NewGoogleServiceClient(datasourceConn),
+		claimsClient:    newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
 	}, nil
 }
 


### PR DESCRIPTION
signin時にユーザー情報を更新するProvisioning functionを追加します。
- JWT検証失敗、userIdpKeyがJWTにない場合エラーレスポンスを返却します
- JWT検証成功時ユーザー情報を更新します
  - Nameはユーザーが手動更新している可能性があるため、JWTの値を使用しません

また、以下の修正を行いました。
- authn functionで実施していたoidcDataの検証をprovisioningに移動
- PutUser時、subに加えuserIdpKeyの値をリクエストのものを使用しないようにJWTの値を使用