### PR TITLE
fix updateFromUserIdpKey

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -102,12 +102,7 @@ func (g *gatewayService) UpdateUserFromIdp(next http.Handler) http.Handler {
 		}
 		// 既存のユーザーであれば、手動でNameを変更している可能性があるので、contextのユーザー名を使用する
 		u, err := getRequestUser(r)
-		if err != nil {
-			appLogger.Infof(ctx, "Unauthenticated: %+v", err)
-			http.Error(w, "Unauthenticated", http.StatusUnauthorized)
-			return
-		}
-		if u.name != "" {
+		if err == nil && u != nil && u.name != "" {
 			putUserRequest.User.Name = u.name
 		}
 		putResp, err := g.iamClient.PutUser(ctx, putUserRequest)

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -534,15 +534,16 @@ func TestUpdateUserFromIdp(t *testing.T) {
 			wantStatusCode: http.StatusForbidden,
 		},
 		{
-			name:       "NG getRequestUser error",
+			name:       "OK getRequestUser error",
 			userID:     "sub",
 			userIdpKey: "uid",
 			claims: &jwt.MapClaims{
 				"username":     "username",
 				"user_idp_key": "uid",
 			},
-			requestUser:    nil,
-			wantStatusCode: http.StatusUnauthorized,
+			mockPutUserResp: &iam.PutUserResponse{},
+			requestUser:     nil,
+			wantStatusCode:  http.StatusOK,
 		},
 		{
 			name:       "NG PutUserError",


### PR DESCRIPTION
UpdateUserFromIdp function内で、getRequestUserの取得にエラー時に処理を続行するよう修正しました
エラー時に401レスポンスを返すことで新規ユーザーのsingin時にユーザーが作成されなかった問題を解消します

UpdateUserFromIdpのGetRequestUserでエラーとなるケースはDBにユーザーが存在しない場合です