### PR TITLE
fix: store projectID for API token

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -345,6 +345,14 @@ func (g *gatewayService) authzProjectForToken(u *requestUser, r *http.Request) b
 	if u.accessTokenID == 0 || u.accessTokenProjectID == 0 {
 		return false
 	}
+	p := &requestProject{}
+	err := bind(p, r)
+	if err != nil {
+		appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
+	}
+	if p.ProjectID != 0 && p.ProjectID != u.accessTokenProjectID {
+		return false
+	}
 	req := &iam.IsAuthorizedTokenRequest{
 		AccessTokenId: u.accessTokenID,
 		ProjectId:     u.accessTokenProjectID,

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -152,45 +152,40 @@ func TestAuthzProjectForToken(t *testing.T) {
 		iamClient: iamMock,
 	}
 	cases := []struct {
-		name         string
-		inputUser    *requestUser
-		inputProject string
-		want         bool
-		mockResp     *iam.IsAuthorizedTokenResponse
-		mockErr      error
+		name      string
+		inputUser *requestUser
+		want      bool
+		mockResp  *iam.IsAuthorizedTokenResponse
+		mockErr   error
 	}{
 		{
-			name:         "OK",
-			inputUser:    &requestUser{accessTokenID: 123},
-			inputProject: "project_id=1",
-			mockResp:     &iam.IsAuthorizedTokenResponse{Ok: true},
-			want:         true,
+			name:      "OK",
+			inputUser: &requestUser{accessTokenID: 123, accessTokenProjectID: 1},
+			mockResp:  &iam.IsAuthorizedTokenResponse{Ok: true},
+			want:      true,
 		},
 		{
-			name:         "NG No token",
-			inputUser:    &requestUser{sub: "sub"},
-			inputProject: "project_id=1",
-			want:         false,
+			name:      "NG No token",
+			inputUser: &requestUser{sub: "sub", accessTokenProjectID: 1},
+			want:      false,
 		},
 		{
-			name:         "NG Invalid project",
-			inputUser:    &requestUser{accessTokenID: 123},
-			inputProject: "project_id=aaa",
-			want:         false,
+			name:      "NG Invalid project",
+			inputUser: &requestUser{accessTokenID: 123, accessTokenProjectID: 0},
+			want:      false,
 		},
 		{
-			name:         "NG IAM error",
-			inputUser:    &requestUser{accessTokenID: 123},
-			inputProject: "project_id=1",
-			want:         false,
-			mockErr:      errors.New("something error"),
+			name:      "NG IAM error",
+			inputUser: &requestUser{accessTokenID: 123, accessTokenProjectID: 1},
+			want:      false,
+			mockErr:   errors.New("something error"),
 		}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.mockResp != nil || c.mockErr != nil {
 				iamMock.On("IsAuthorizedToken", mock.Anything, mock.Anything).Return(c.mockResp, c.mockErr).Once()
 			}
-			req, _ := http.NewRequest(http.MethodGet, "/api/v1/service/action?"+c.inputProject, nil)
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/service/action/", nil)
 			got := svc.authzProjectForToken(c.inputUser, req)
 			if got != c.want {
 				t.Fatalf("Unexpected response. want=%t, got=%t", c.want, got)


### PR DESCRIPTION
APIトークンでリクエストが来た場合に、プロジェクトIDの検証を方法を変更したいです。

### 旧

リクエストパラメータ（ `?project_id=xxx` など）からプロジェクトIDを引いていました

### 新

アクセストークン自体がプロジェクトIDに紐づくものなので、アクセストークンのデコード処理でトークンIDとプロジェクトIDを取得・保持し、検証するようにしたいです。

### 変更したい理由

今後、アクセストークンでGitHubActionsからのリクエストを受ける際に、プロジェクトIDをわざわざ指定しなくても良い形式にしたいためです。
