### PR TITLE
suport: accesstoken signin

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -62,9 +62,14 @@ func signinHandler(w http.ResponseWriter, r *http.Request) {
 		Path:   "/",
 		Secure: r.Header.Get("X-Forwarded-Proto") == "https",
 	})
-	writeResponse(ctx, w, http.StatusOK, map[string]interface{}{
-		"user_id": signinUser.userID,
-	})
+	resp := map[string]interface{}{}
+	if signinUser.userID != 0 {
+		resp["user_id"] = signinUser.userID
+	} else if signinUser.accessTokenID != 0 && signinUser.accessTokenProjectID != 0 {
+		resp["access_token_id"] = signinUser.accessTokenID
+		resp["project_id"] = signinUser.accessTokenProjectID
+	}
+	writeResponse(ctx, w, http.StatusOK, resp)
 }
 
 func (g *gatewayService) UpdateUserFromIdp(next http.Handler) http.Handler {


### PR DESCRIPTION
アクセストークンからのリクエストでsinginした時に、紐づくプロジェクト情報などを返す処理を追加します。

今まではユーザからのSigninのみの想定でしたが、アクセストークン経由のAPIアクセスを受け入れます。
アクセストークン利用者は、対象のプロジェクトIDをこのAPIで取得することができるようになり、それを用いて他の各種APIへのアクセスが可能になります。
（事前にプロジェクトIDを管理することなくプログラム内で動的にプロジェクトID取得をしたいユースケースに対応）
