### PR TITLE
fix: signout handler

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -278,7 +278,7 @@ func validCSRFToken(r *http.Request) bool {
 	if headerToken == "" {
 		return false
 	}
-	cookieToken, err := r.Cookie("XSRF-TOKEN")
+	cookieToken, err := r.Cookie(XSRF_TOKEN)
 	if err != nil || cookieToken.Value == "" {
 		return false
 	}

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -84,7 +84,7 @@ func TestValidCSRFToken(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPost, "/api/v1/test", nil)
 			req.Header.Add("X-XSRF-TOKEN", c.inputHeader)
-			req.AddCookie(&http.Cookie{Name: "XSRF-TOKEN", Value: c.inputCookie})
+			req.AddCookie(&http.Cookie{Name: XSRF_TOKEN, Value: c.inputCookie})
 			got := validCSRFToken(req)
 			if got != c.want {
 				t.Fatalf("Unexpected response. want=%t, got=%t", c.want, got)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ type AppConfig struct {
 	UserIdentityHeader string   `required:"true" split_words:"true" default:"x-amzn-oidc-identity"`
 	OidcDataHeader     string   `required:"true" split_words:"true" default:"x-amzn-oidc-data"`
 	IdpProviderName    []string `required:"true" split_words:"true" default:"YOUR_IDP1,YOUR_IDP2"`
+	SessionCookieName  []string `split_words:"true" default:"AWSELBAuthSessionCookie-0,AWSELBAuthSessionCookie-1"`
 	VerifyIDToken      bool     `split_words:"true" default:"false"`
 	UserIdpKey         string   `split_words:"true" default:"preferred_username"`
 	Region             string   `default:"ap-northeast-1"`

--- a/router.go
+++ b/router.go
@@ -34,7 +34,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 		})
 		r.Route("/signout", func(r chi.Router) {
 			r.Use(svc.UpdateUserFromIdp)
-			r.Get("/", signoutHandler)
+			r.Get("/", svc.signoutHandler)
 		})
 
 		r.Route("/finding", func(r chi.Router) {

--- a/service.go
+++ b/service.go
@@ -30,22 +30,23 @@ const (
 )
 
 type gatewayService struct {
-	envName          string
-	port             string
-	uidHeader        string
-	oidcDataHeader   string
-	findingClient    finding.FindingServiceClient
-	iamClient        iam.IAMServiceClient
-	projectClient    project.ProjectServiceClient
-	alertClient      alert.AlertServiceClient
-	reportClient     report.ReportServiceClient
-	awsClient        aws.AWSServiceClient
-	osintClient      osint.OsintServiceClient
-	diagnosisClient  diagnosis.DiagnosisServiceClient
-	codeClient       code.CodeServiceClient
-	googleClient     google.GoogleServiceClient
-	claimsClient     claimsInterface
-	datasourceClient datasource.DataSourceServiceClient
+	envName           string
+	port              string
+	uidHeader         string
+	oidcDataHeader    string
+	sessionCookieName []string
+	findingClient     finding.FindingServiceClient
+	iamClient         iam.IAMServiceClient
+	projectClient     project.ProjectServiceClient
+	alertClient       alert.AlertServiceClient
+	reportClient      report.ReportServiceClient
+	awsClient         aws.AWSServiceClient
+	osintClient       osint.OsintServiceClient
+	diagnosisClient   diagnosis.DiagnosisServiceClient
+	codeClient        code.CodeServiceClient
+	googleClient      google.GoogleServiceClient
+	claimsClient      claimsInterface
+	datasourceClient  datasource.DataSourceServiceClient
 }
 
 func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
@@ -64,22 +65,23 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		return nil, err
 	}
 	return &gatewayService{
-		envName:          conf.EnvName,
-		port:             conf.Port,
-		uidHeader:        conf.UserIdentityHeader,
-		oidcDataHeader:   conf.OidcDataHeader,
-		findingClient:    finding.NewFindingServiceClient(coreConn),
-		iamClient:        iam.NewIAMServiceClient(coreConn),
-		projectClient:    project.NewProjectServiceClient(coreConn),
-		alertClient:      alert.NewAlertServiceClient(coreConn),
-		reportClient:     report.NewReportServiceClient(coreConn),
-		awsClient:        aws.NewAWSServiceClient(datasourceConn),
-		osintClient:      osint.NewOsintServiceClient(datasourceConn),
-		diagnosisClient:  diagnosis.NewDiagnosisServiceClient(datasourceConn),
-		codeClient:       code.NewCodeServiceClient(datasourceConn),
-		googleClient:     google.NewGoogleServiceClient(datasourceConn),
-		claimsClient:     newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
-		datasourceClient: datasource.NewDataSourceServiceClient(datasourceConn),
+		envName:           conf.EnvName,
+		port:              conf.Port,
+		uidHeader:         conf.UserIdentityHeader,
+		oidcDataHeader:    conf.OidcDataHeader,
+		sessionCookieName: conf.SessionCookieName,
+		findingClient:     finding.NewFindingServiceClient(coreConn),
+		iamClient:         iam.NewIAMServiceClient(coreConn),
+		projectClient:     project.NewProjectServiceClient(coreConn),
+		alertClient:       alert.NewAlertServiceClient(coreConn),
+		reportClient:      report.NewReportServiceClient(coreConn),
+		awsClient:         aws.NewAWSServiceClient(datasourceConn),
+		osintClient:       osint.NewOsintServiceClient(datasourceConn),
+		diagnosisClient:   diagnosis.NewDiagnosisServiceClient(datasourceConn),
+		codeClient:        code.NewCodeServiceClient(datasourceConn),
+		googleClient:      google.NewGoogleServiceClient(datasourceConn),
+		claimsClient:      newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
+		datasourceClient:  datasource.NewDataSourceServiceClient(datasourceConn),
 	}, nil
 }
 


### PR DESCRIPTION
セッションCookie名をサービスのパラメータにもたせて消し込むように修正します。
Backendに到達する際に、LB側で管理しているCookieの値が渡ってこないため以前の実装では不十分だということがわかりました