### PR TITLE
fix: session timeout for csrf

### DIFF
--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 func TestSigninHandler(t *testing.T) {
+	svc := gatewayService{
+		sessionTimeoutSec: 1,
+	}
 	cases := []struct {
 		name  string
 		input *requestUser
@@ -39,7 +42,7 @@ func TestSigninHandler(t *testing.T) {
 			rec := httptest.NewRecorder()
 			req, _ := http.NewRequest(http.MethodGet, "/api/v1/signin", nil)
 			req = req.WithContext(context.WithValue(req.Context(), userKey, c.input))
-			signinHandler(rec, req)
+			svc.signinHandler(rec, req)
 			got := rec.Result().StatusCode
 			if got != c.want {
 				t.Fatalf("Unexpected responce. want=%d, got=%d", c.want, got)
@@ -428,7 +431,7 @@ func GetTestHandler() http.HandlerFunc {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
-			log.Fatalf(err.Error())
+			log.Fatal(err)
 		}
 	}
 	return http.HandlerFunc(fn)

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ type AppConfig struct {
 	OidcDataHeader     string   `required:"true" split_words:"true" default:"x-amzn-oidc-data"`
 	IdpProviderName    []string `required:"true" split_words:"true" default:"YOUR_IDP1,YOUR_IDP2"`
 	SessionCookieName  []string `split_words:"true" default:"AWSELBAuthSessionCookie-0,AWSELBAuthSessionCookie-1"`
+	SessionTimeoutSec  int      `split_words:"true" default:"2592000"`
 	VerifyIDToken      bool     `split_words:"true" default:"false"`
 	UserIdpKey         string   `split_words:"true" default:"preferred_username"`
 	Region             string   `default:"ap-northeast-1"`

--- a/router.go
+++ b/router.go
@@ -30,7 +30,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Route("/signin", func(r chi.Router) {
 			r.Use(svc.UpdateUserFromIdp)
-			r.Get("/", signinHandler)
+			r.Get("/", svc.signinHandler)
 		})
 		r.Route("/signout", func(r chi.Router) {
 			r.Use(svc.UpdateUserFromIdp)

--- a/service.go
+++ b/service.go
@@ -36,6 +36,7 @@ type gatewayService struct {
 	uidHeader         string
 	oidcDataHeader    string
 	sessionCookieName []string
+	sessionTimeoutSec int
 	findingClient     finding.FindingServiceClient
 	iamClient         iam.IAMServiceClient
 	projectClient     project.ProjectServiceClient
@@ -72,6 +73,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		uidHeader:         conf.UserIdentityHeader,
 		oidcDataHeader:    conf.OidcDataHeader,
 		sessionCookieName: conf.SessionCookieName,
+		sessionTimeoutSec: conf.SessionTimeoutSec,
 		findingClient:     finding.NewFindingServiceClient(coreConn),
 		iamClient:         iam.NewIAMServiceClient(coreConn),
 		projectClient:     project.NewProjectServiceClient(coreConn),

--- a/signin.go
+++ b/signin.go
@@ -14,7 +14,7 @@ const (
 )
 
 // signinHandler: OIDC proxy backend signin process.
-func signinHandler(w http.ResponseWriter, r *http.Request) {
+func (g *gatewayService) signinHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	signinUser, err := getRequestUser(r)
 	if err != nil {
@@ -28,6 +28,7 @@ func signinHandler(w http.ResponseWriter, r *http.Request) {
 		Name:   XSRF_TOKEN,
 		Value:  base64.RawURLEncoding.EncodeToString(token),
 		Path:   "/",
+		MaxAge: g.sessionTimeoutSec,
 		Secure: r.Header.Get("X-Forwarded-Proto") == "https",
 	})
 	appLogger.WithItems(ctx, logging.InfoLevel, map[string]interface{}{"user_id": signinUser.userID}, "Signin")


### PR DESCRIPTION
ログイン時に設定しているXSRF-TOKENがブラウザセッションで管理されていましたが、タイムアウトを設けます。
現状、ログイン状態なのに、XSRF-TOKEN Cookieが切れてしまっている場合に403エラーが発生します。

例えば、しばらくRISKENにアクセスしてない状態の際に、URL直リンクアクセス→ログイン成功してもブラウザ上XSRF-TOKENクッキーが消えてるケースがあります。
その影響で、このエラーが頻発してそうなので（仮説）、セッション管理を見直したいです。
（ログインセッションに近い状態にして、403エラーなどの発生を抑制したい）