### PR TITLE
add: create GitHub Actions workflow for building and tagging PR gateway container

### DIFF
--- a/.github/workflows/build-pr-gateway.yml
+++ b/.github/workflows/build-pr-gateway.yml
@@ -1,0 +1,20 @@
+name: Build and Tag Container for PR Gateway
+
+on: 
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build-pr-gateway:
+    uses: ca-risken/.github/.github/workflows/build-pr.yml@main
+    with:
+      runs_on: codebuild-mimosa-gateway-pr-runner-${{ github.run_id }}-${{ github.run_attempt }}
+      install_go_version: "1.23.3"
+      golangci_lint_version: "v1.60.1"
+      image_prefix: "risken-gateway"
+      test_command: "go-test"
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}

--- a/.github/workflows/build-pr-gateway.yml
+++ b/.github/workflows/build-pr-gateway.yml
@@ -13,7 +13,6 @@ jobs:
       install_go_version: "1.23.3"
       golangci_lint_version: "v1.60.1"
       image_prefix: "risken-gateway"
-      test_command: "go-test"
     secrets:
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
gatewayに関連付けられていたcodebuildを置き換えるためにgithub actionsのワークフローを追加します。
awsやcoreのものとgolangのバージョンを除き、同じ内容です。