### PR TITLE
Add AuthzOnlyProjectRoleHolder middleware and apply it to put-alert-first-viewed-at endpoint

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -349,7 +349,7 @@ func (g *gatewayService) authzOnlyProjectRoleHolder(next http.Handler) http.Hand
 		if err := bind(p, r); err != nil {
 			appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
 		}
-		if !g.hasProjectRole(ctx, u.userID, p.ProjectID) {
+		if !g.isAuthorizedProject(ctx, u.userID, p.ProjectID, "/api/v1/alert/list-alert") {
 			http.Error(w, "You are not a member of this project", http.StatusForbidden)
 			return
 		}
@@ -359,20 +359,6 @@ func (g *gatewayService) authzOnlyProjectRoleHolder(next http.Handler) http.Hand
 	return http.HandlerFunc(fn)
 }
 
-func (g *gatewayService) hasProjectRole(ctx context.Context, userID, projectID uint32) bool {
-	if userID == 0 || projectID == 0 {
-		return false
-	}
-	resp, err := g.iamClient.ListRole(ctx, &iam.ListRoleRequest{
-		ProjectId: projectID,
-		UserId:    userID,
-	})
-	if err != nil {
-		appLogger.Errorf(ctx, "Failed to ListRole request, user_id=%d, project_id=%d, err=%+v", userID, projectID, err)
-		return false
-	}
-	return len(resp.RoleId) > 0
-}
 
 func isHumanAccess(u *requestUser) bool {
 	if u == nil || zero.IsZeroVal(u.userID) {

--- a/authorizer.go
+++ b/authorizer.go
@@ -345,14 +345,33 @@ func (g *gatewayService) authzOnlyProjectMember(next http.Handler) http.Handler 
 			http.Error(w, "This API is only available for human access", http.StatusForbidden)
 			return
 		}
-		if !g.authzProject(u, r) {
-			http.Error(w, "Unauthorized the project resource for human access", http.StatusForbidden)
+		p := &requestProject{}
+		if err := bind(p, r); err != nil {
+			appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
+		}
+		if !g.isProjectMember(ctx, u.userID, p.ProjectID) {
+			http.Error(w, "You are not a member of this project", http.StatusForbidden)
 			return
 		}
 		r.Body = io.NopCloser(bytes.NewBuffer(buf))
 		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)
+}
+
+func (g *gatewayService) isProjectMember(ctx context.Context, userID, projectID uint32) bool {
+	if zero.IsZeroVal(userID) || zero.IsZeroVal(projectID) {
+		return false
+	}
+	resp, err := g.iamClient.ListRole(ctx, &iam.ListRoleRequest{
+		ProjectId: projectID,
+		UserId:    userID,
+	})
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to ListRole request, user_id=%d, project_id=%d, err=%+v", userID, projectID, err)
+		return false
+	}
+	return len(resp.RoleId) > 0
 }
 
 func isHumanAccess(u *requestUser) bool {

--- a/authorizer.go
+++ b/authorizer.go
@@ -349,7 +349,7 @@ func (g *gatewayService) authzWithProjectMember(next http.Handler) http.Handler 
 		if err := bind(p, r); err != nil {
 			appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
 		}
-		if zero.IsZeroVal(p.ProjectID) {
+		if p.ProjectID == 0 {
 			http.Error(w, "You are not a member of this project", http.StatusForbidden)
 			return
 		}

--- a/authorizer.go
+++ b/authorizer.go
@@ -349,6 +349,10 @@ func (g *gatewayService) authzWithProjectMember(next http.Handler) http.Handler 
 		if err := bind(p, r); err != nil {
 			appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
 		}
+		if zero.IsZeroVal(p.ProjectID) {
+			http.Error(w, "You are not a member of this project", http.StatusForbidden)
+			return
+		}
 		// TODO: Using a dummy action. Consider replacing with a dedicated API action.
 		if !g.isAuthorizedProject(ctx, u.userID, p.ProjectID, "/api/v1/alert/list-alert") {
 			http.Error(w, "You are not a member of this project", http.StatusForbidden)

--- a/authorizer.go
+++ b/authorizer.go
@@ -324,6 +324,37 @@ func (g *gatewayService) verifyCSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
+func (g *gatewayService) authzOnlyProjectMember(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			appLogger.Errorf(ctx, "Failed to read body, err=%+v", err)
+			http.Error(w, "Could not read body", http.StatusInternalServerError)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+		u, err := getRequestUser(r)
+		if err != nil {
+			appLogger.Infof(ctx, "Unauthenticated: %+v", err)
+			http.Error(w, "Unauthenticated", http.StatusUnauthorized)
+			return
+		}
+		if !isHumanAccess(u) {
+			http.Error(w, "This API is only available for human access", http.StatusForbidden)
+			return
+		}
+		if !g.authzProject(u, r) {
+			http.Error(w, "Unauthorized the project resource for human access", http.StatusForbidden)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+		next.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}
+
 func isHumanAccess(u *requestUser) bool {
 	if u == nil || zero.IsZeroVal(u.userID) {
 		return false

--- a/authorizer.go
+++ b/authorizer.go
@@ -324,7 +324,7 @@ func (g *gatewayService) verifyCSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-func (g *gatewayService) authzOnlyProjectRoleHolder(next http.Handler) http.Handler {
+func (g *gatewayService) authzWithProjectMember(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		buf, err := io.ReadAll(r.Body)
@@ -349,6 +349,7 @@ func (g *gatewayService) authzOnlyProjectRoleHolder(next http.Handler) http.Hand
 		if err := bind(p, r); err != nil {
 			appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
 		}
+		// TODO: Using a dummy action. Consider replacing with a dedicated API action.
 		if !g.isAuthorizedProject(ctx, u.userID, p.ProjectID, "/api/v1/alert/list-alert") {
 			http.Error(w, "You are not a member of this project", http.StatusForbidden)
 			return

--- a/authorizer.go
+++ b/authorizer.go
@@ -324,7 +324,7 @@ func (g *gatewayService) verifyCSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-func (g *gatewayService) authzOnlyProjectMember(next http.Handler) http.Handler {
+func (g *gatewayService) authzOnlyProjectRoleHolder(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		buf, err := io.ReadAll(r.Body)
@@ -349,7 +349,7 @@ func (g *gatewayService) authzOnlyProjectMember(next http.Handler) http.Handler 
 		if err := bind(p, r); err != nil {
 			appLogger.Warnf(ctx, "Failed to bind request, err=%+v", err)
 		}
-		if !g.isProjectMember(ctx, u.userID, p.ProjectID) {
+		if !g.hasProjectRole(ctx, u.userID, p.ProjectID) {
 			http.Error(w, "You are not a member of this project", http.StatusForbidden)
 			return
 		}
@@ -359,8 +359,8 @@ func (g *gatewayService) authzOnlyProjectMember(next http.Handler) http.Handler 
 	return http.HandlerFunc(fn)
 }
 
-func (g *gatewayService) isProjectMember(ctx context.Context, userID, projectID uint32) bool {
-	if zero.IsZeroVal(userID) || zero.IsZeroVal(projectID) {
+func (g *gatewayService) hasProjectRole(ctx context.Context, userID, projectID uint32) bool {
+	if userID == 0 || projectID == 0 {
 		return false
 	}
 	resp, err := g.iamClient.ListRole(ctx, &iam.ListRoleRequest{

--- a/router.go
+++ b/router.go
@@ -148,7 +148,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(middleware.AllowContentType(contenTypeJSON))
 				r.Post("/request-project-role-notification", svc.requestProjectRoleNotificationAlertHandler)
 				r.Group(func(r chi.Router) {
-					r.Use(svc.authzOnlyProjectRoleHolder)
+					r.Use(svc.authzWithProjectMember)
 					r.Post("/put-alert-first-viewed-at", svc.putAlertFirstViewedAtAlertHandler)
 				})
 				r.Group(func(r chi.Router) {

--- a/router.go
+++ b/router.go
@@ -148,7 +148,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(middleware.AllowContentType(contenTypeJSON))
 				r.Post("/request-project-role-notification", svc.requestProjectRoleNotificationAlertHandler)
 				r.Group(func(r chi.Router) {
-					r.Use(svc.authzOnlyProjectMember)
+					r.Use(svc.authzOnlyProjectRoleHolder)
 					r.Post("/put-alert-first-viewed-at", svc.putAlertFirstViewedAtAlertHandler)
 				})
 				r.Group(func(r chi.Router) {

--- a/router.go
+++ b/router.go
@@ -148,9 +148,12 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(middleware.AllowContentType(contenTypeJSON))
 				r.Post("/request-project-role-notification", svc.requestProjectRoleNotificationAlertHandler)
 				r.Group(func(r chi.Router) {
+					r.Use(svc.authzOnlyProjectMember)
+					r.Post("/put-alert-first-viewed-at", svc.putAlertFirstViewedAtAlertHandler)
+				})
+				r.Group(func(r chi.Router) {
 					r.Use(svc.authzWithProject)
 					r.Post("/put-alert", svc.putAlertAlertHandler)
-					r.Post("/put-alert-first-viewed-at", svc.putAlertFirstViewedAtAlertHandler)
 					r.Post("/put-condition", svc.putAlertConditionAlertHandler)
 					r.Post("/put-rule", svc.putAlertRuleAlertHandler)
 					r.Post("/put-condition_rule", svc.putAlertCondRuleAlertHandler)


### PR DESCRIPTION
put-alert-first-viewed-atの認可ミドルウェアを分離し、AuthzOnlyProjectRoleHolderを使って置き換えます。
このミドルウェアは

- そのユーザーがProjectの閲覧権限を持つ
- トークンアクセスではない

ときに認可成功します。

以下の動作確認済みです

- [x] put-alert-first-viewed-atがViewer権限で成功する（get|listでも成功する）
- [x] put-alert-first-viewed-atがViewer権限なければ失敗する
- [x] put-alert-first-viewed-atがOrgのViewer権限で成功する
- [x] put-alert-first-viewed-atにAPIアクセスできない