### PR TITLE
[add]verify-slack-signature

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -366,6 +366,7 @@ func isHumanAccess(u *requestUser) bool {
 var ignoreURI4CSRF = []string{
 	"/healthz",
 	"/api/v1/signin",
+	"/api/v1/slack/actions",
 }
 
 func shouldVerifyCSRFTokenURI(uri string) bool {

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -769,6 +769,11 @@ func TestShouldVerifyCSRFTokenURI(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "ignore Slack action URI",
+			input: "/api/v1/slack/actions",
+			want:  false,
+		},
+		{
 			name:  "slash suffix 1",
 			input: "/api/v1/uri/",
 			want:  true,
@@ -776,6 +781,11 @@ func TestShouldVerifyCSRFTokenURI(t *testing.T) {
 		{
 			name:  "slash suffix 2",
 			input: "/api/v1/signin/",
+			want:  false,
+		},
+		{
+			name:  "slash suffix Slack action URI",
+			input: "/api/v1/slack/actions/",
 			want:  false,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,10 @@ type AppConfig struct {
 	WriteTimeoutSec      int    `split_words:"true" default:"30"`
 	IdleTimeoutSec       int    `split_words:"true" default:"120"`
 	MaxHeaderBytes       int    `split_words:"true" default:"1048576"`
+
+	SlackSigningSecret       string `split_words:"true"`
+	SlackActionSigningSecret string `split_words:"true"`
+	SlackBotToken            string `split_words:"true"`
 }
 
 func main() {

--- a/router.go
+++ b/router.go
@@ -29,6 +29,9 @@ func newRouter(svc *gatewayService) *chi.Mux {
 	r.NotFound(notFoundHandler)
 
 	r.Route("/api/v1", func(r chi.Router) {
+		r.Route("/slack", func(r chi.Router) {
+			r.Post("/actions", svc.slackActionHandler)
+		})
 		r.Route("/signin", func(r chi.Router) {
 			r.Use(svc.UpdateUserFromIdp)
 			r.Get("/", svc.signinHandler)

--- a/service.go
+++ b/service.go
@@ -80,6 +80,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		appLogger.Errorf(ctx, "Failed to get grpc connection to datasource api service, err=%+v", err)
 		return nil, err
 	}
+	warnSlackActionConfig(ctx, conf)
 	return &gatewayService{
 		envName:                  conf.EnvName,
 		port:                     conf.Port,
@@ -108,6 +109,22 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		slackActionSigningSecret: conf.SlackActionSigningSecret,
 		slackViewOpener:          newSlackAPIClient(conf.SlackBotToken),
 	}, nil
+}
+
+func warnSlackActionConfig(ctx context.Context, conf *AppConfig) {
+	missingConfigs := []string{}
+	if conf.SlackSigningSecret == "" {
+		missingConfigs = append(missingConfigs, "SLACK_SIGNING_SECRET")
+	}
+	if conf.SlackActionSigningSecret == "" {
+		missingConfigs = append(missingConfigs, "SLACK_ACTION_SIGNING_SECRET")
+	}
+	if conf.SlackBotToken == "" {
+		missingConfigs = append(missingConfigs, "SLACK_BOT_TOKEN")
+	}
+	if len(missingConfigs) > 0 {
+		appLogger.Warnf(ctx, "Slack action endpoint is not fully configured; requests will fail until missing config is set, missing=%v", missingConfigs)
+	}
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/service.go
+++ b/service.go
@@ -59,6 +59,10 @@ type gatewayService struct {
 	aiClient           ai.AIServiceClient
 	claimsClient       claimsInterface
 	datasourceClient   datasource.DataSourceServiceClient
+
+	slackSigningSecret       string
+	slackActionSigningSecret string
+	slackViewOpener          slackViewOpener
 }
 
 func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
@@ -77,29 +81,32 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		return nil, err
 	}
 	return &gatewayService{
-		envName:            conf.EnvName,
-		port:               conf.Port,
-		uidHeader:          conf.UserIdentityHeader,
-		oidcDataHeader:     conf.OidcDataHeader,
-		sessionCookieName:  conf.SessionCookieName,
-		sessionTimeoutSec:  conf.SessionTimeoutSec,
-		findingClient:      finding.NewFindingServiceClient(coreConn),
-		iamClient:          iam.NewIAMServiceClient(coreConn),
-		projectClient:      project.NewProjectServiceClient(coreConn),
-		alertClient:        alert.NewAlertServiceClient(coreConn),
-		reportClient:       report.NewReportServiceClient(coreConn),
-		organizationClient: organization.NewOrganizationServiceClient(coreConn),
-		org_iamClient:      org_iam.NewOrgIAMServiceClient(coreConn),
-		org_alertClient:    org_alert.NewOrgAlertServiceClient(coreConn),
-		awsClient:          aws.NewAWSServiceClient(datasourceConn),
-		osintClient:        osint.NewOsintServiceClient(datasourceConn),
-		diagnosisClient:    diagnosis.NewDiagnosisServiceClient(datasourceConn),
-		codeClient:         code.NewCodeServiceClient(datasourceConn),
-		googleClient:       google.NewGoogleServiceClient(datasourceConn),
-		azureClient:        azure.NewAzureServiceClient(datasourceConn),
-		aiClient:           ai.NewAIServiceClient(coreConn),
-		claimsClient:       newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
-		datasourceClient:   datasource.NewDataSourceServiceClient(datasourceConn),
+		envName:                  conf.EnvName,
+		port:                     conf.Port,
+		uidHeader:                conf.UserIdentityHeader,
+		oidcDataHeader:           conf.OidcDataHeader,
+		sessionCookieName:        conf.SessionCookieName,
+		sessionTimeoutSec:        conf.SessionTimeoutSec,
+		findingClient:            finding.NewFindingServiceClient(coreConn),
+		iamClient:                iam.NewIAMServiceClient(coreConn),
+		projectClient:            project.NewProjectServiceClient(coreConn),
+		alertClient:              alert.NewAlertServiceClient(coreConn),
+		reportClient:             report.NewReportServiceClient(coreConn),
+		organizationClient:       organization.NewOrganizationServiceClient(coreConn),
+		org_iamClient:            org_iam.NewOrgIAMServiceClient(coreConn),
+		org_alertClient:          org_alert.NewOrgAlertServiceClient(coreConn),
+		awsClient:                aws.NewAWSServiceClient(datasourceConn),
+		osintClient:              osint.NewOsintServiceClient(datasourceConn),
+		diagnosisClient:          diagnosis.NewDiagnosisServiceClient(datasourceConn),
+		codeClient:               code.NewCodeServiceClient(datasourceConn),
+		googleClient:             google.NewGoogleServiceClient(datasourceConn),
+		azureClient:              azure.NewAzureServiceClient(datasourceConn),
+		aiClient:                 ai.NewAIServiceClient(coreConn),
+		claimsClient:             newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
+		datasourceClient:         datasource.NewDataSourceServiceClient(datasourceConn),
+		slackSigningSecret:       conf.SlackSigningSecret,
+		slackActionSigningSecret: conf.SlackActionSigningSecret,
+		slackViewOpener:          newSlackAPIClient(conf.SlackBotToken),
 	}, nil
 }
 

--- a/service_slack.go
+++ b/service_slack.go
@@ -24,9 +24,10 @@ const (
 	slackActionCallbackPend    = "risken_slack_action_pend"
 	slackActionCallbackArchive = "risken_slack_action_archive"
 
-	slackSignatureVersion = "v0"
-	slackSignatureMaxAge  = 5 * time.Minute
-	slackViewsOpenURL     = "https://slack.com/api/views.open"
+	slackSignatureVersion  = "v0"
+	slackSignatureMaxAge   = 5 * time.Minute
+	slackHTTPClientTimeout = 10 * time.Second
+	slackViewsOpenURL      = "https://slack.com/api/views.open"
 )
 
 var (
@@ -117,7 +118,7 @@ type slackTextObject struct {
 func newSlackAPIClient(token string) *slackAPIClient {
 	return &slackAPIClient{
 		token:      token,
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{Timeout: slackHTTPClientTimeout},
 	}
 }
 
@@ -379,15 +380,10 @@ func plainText(text string) slackTextObject {
 }
 
 func writeSlackEphemeralResponse(w http.ResponseWriter, text string) {
-	body, err := json.Marshal(map[string]string{
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{
 		"response_type": "ephemeral",
 		"text":          text,
 	})
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(body)
 }

--- a/service_slack.go
+++ b/service_slack.go
@@ -26,8 +26,10 @@ const (
 
 	slackSignatureVersion  = "v0"
 	slackSignatureMaxAge   = 5 * time.Minute
-	slackHTTPClientTimeout = 10 * time.Second
-	slackViewsOpenURL      = "https://slack.com/api/views.open"
+	slackHTTPClientTimeout       = 10 * time.Second
+	slackViewsOpenURL            = "https://slack.com/api/views.open"
+	slackAPIResponseMaxBytes     = 64 * 1024
+	slackAPIResponseLogMaxBytes  = 256
 )
 
 var (
@@ -115,6 +117,24 @@ type slackTextObject struct {
 	Text string `json:"text"`
 }
 
+func readSlackAPIResponseBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, slackAPIResponseMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > slackAPIResponseMaxBytes {
+		return nil, fmt.Errorf("slack api response body exceeds max size %d", slackAPIResponseMaxBytes)
+	}
+	return body, nil
+}
+
+func truncateSlackResponseForLog(body []byte) string {
+	if len(body) <= slackAPIResponseLogMaxBytes {
+		return string(body)
+	}
+	return string(body[:slackAPIResponseLogMaxBytes]) + "...(truncated)"
+}
+
 func newSlackAPIClient(token string) *slackAPIClient {
 	return &slackAPIClient{
 		token:      token,
@@ -146,12 +166,12 @@ func (c *slackAPIClient) OpenView(ctx context.Context, triggerID string, view sl
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := readSlackAPIResponseBody(resp.Body)
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("slack views.open status=%d body=%s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("slack views.open status=%d body=%s", resp.StatusCode, truncateSlackResponseForLog(respBody))
 	}
 	var slackResp slackAPIResponse
 	if err := json.Unmarshal(respBody, &slackResp); err != nil {

--- a/service_slack.go
+++ b/service_slack.go
@@ -1,0 +1,393 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	slackActionEndpointPath = "/api/v1/slack/actions"
+	slackActionPend         = "pend"
+	slackActionArchive      = "archive"
+
+	slackActionCallbackPend    = "risken_slack_action_pend"
+	slackActionCallbackArchive = "risken_slack_action_archive"
+
+	slackSignatureVersion = "v0"
+	slackSignatureMaxAge  = 5 * time.Minute
+	slackViewsOpenURL     = "https://slack.com/api/views.open"
+)
+
+var (
+	errSlackSigningSecretNotConfigured       = errors.New("slack signing secret is not configured")
+	errSlackActionSigningSecretNotConfigured = errors.New("slack action signing secret is not configured")
+	errSlackBotTokenNotConfigured            = errors.New("slack bot token is not configured")
+	errSlackRequestTimestampMissing          = errors.New("slack request timestamp is missing")
+	errSlackRequestTimestampExpired          = errors.New("slack request timestamp is expired")
+	errSlackRequestSignatureInvalid          = errors.New("slack request signature is invalid")
+	errSlackInteractionPayloadMissing        = errors.New("slack interaction payload is missing")
+	errSlackActionPayloadMissing             = errors.New("slack action payload is missing")
+	errSlackActionPayloadInvalid             = errors.New("slack action payload is invalid")
+	errSlackActionPayloadExpired             = errors.New("slack action payload is expired")
+	errSlackActionPayloadSignatureInvalid    = errors.New("slack action payload signature is invalid")
+)
+
+type slackViewOpener interface {
+	OpenView(ctx context.Context, triggerID string, view slackModalView) error
+}
+
+type slackAPIClient struct {
+	token      string
+	httpClient *http.Client
+}
+
+type slackOpenViewRequest struct {
+	TriggerID string         `json:"trigger_id"`
+	View      slackModalView `json:"view"`
+}
+
+type slackAPIResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+type slackInteractionPayload struct {
+	Type      string                   `json:"type"`
+	TriggerID string                   `json:"trigger_id"`
+	Actions   []slackInteractionAction `json:"actions"`
+}
+
+type slackInteractionAction struct {
+	Name     string `json:"name"`
+	ActionID string `json:"action_id"`
+	Value    string `json:"value"`
+}
+
+type slackActionPayload struct {
+	Action    string `json:"action"`
+	ProjectID uint32 `json:"project_id"`
+	FindingID uint64 `json:"finding_id"`
+	IssuedAt  int64  `json:"issued_at"`
+	ExpiresAt int64  `json:"expires_at"`
+	Signature string `json:"signature"`
+}
+
+type slackModalView struct {
+	Type            string             `json:"type"`
+	CallbackID      string             `json:"callback_id"`
+	PrivateMetadata string             `json:"private_metadata"`
+	Title           slackTextObject    `json:"title"`
+	Submit          slackTextObject    `json:"submit"`
+	Close           slackTextObject    `json:"close"`
+	Blocks          []slackBlockObject `json:"blocks"`
+}
+
+type slackBlockObject struct {
+	Type     string              `json:"type"`
+	BlockID  string              `json:"block_id,omitempty"`
+	Text     *slackTextObject    `json:"text,omitempty"`
+	Label    *slackTextObject    `json:"label,omitempty"`
+	Element  *slackElementObject `json:"element,omitempty"`
+	Optional bool                `json:"optional,omitempty"`
+}
+
+type slackElementObject struct {
+	Type        string           `json:"type"`
+	ActionID    string           `json:"action_id"`
+	Placeholder *slackTextObject `json:"placeholder,omitempty"`
+	Multiline   bool             `json:"multiline,omitempty"`
+}
+
+type slackTextObject struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func newSlackAPIClient(token string) *slackAPIClient {
+	return &slackAPIClient{
+		token:      token,
+		httpClient: http.DefaultClient,
+	}
+}
+
+func (c *slackAPIClient) OpenView(ctx context.Context, triggerID string, view slackModalView) error {
+	if c.token == "" {
+		return errSlackBotTokenNotConfigured
+	}
+	body, err := json.Marshal(slackOpenViewRequest{
+		TriggerID: triggerID,
+		View:      view,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackViewsOpenURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("slack views.open status=%d body=%s", resp.StatusCode, string(respBody))
+	}
+	var slackResp slackAPIResponse
+	if err := json.Unmarshal(respBody, &slackResp); err != nil {
+		return err
+	}
+	if !slackResp.OK {
+		return fmt.Errorf("slack views.open error=%s", slackResp.Error)
+	}
+	return nil
+}
+
+func (g *gatewayService) slackActionHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to read Slack action request body, err=%+v", err)
+		http.Error(w, "Could not read body", http.StatusInternalServerError)
+		return
+	}
+
+	if err := verifySlackRequestSignature(g.slackSigningSecret, r.Header, body, time.Now()); err != nil {
+		appLogger.Warnf(ctx, "Rejected Slack action request signature, err=%+v", err)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	interaction, rawActionPayload, err := parseSlackInteractionPayload(body)
+	if err != nil {
+		appLogger.Warnf(ctx, "Failed to parse Slack interaction payload, err=%+v", err)
+		writeSlackEphemeralResponse(w, "Failed to parse Slack action payload.")
+		return
+	}
+
+	actionPayload, err := parseAndVerifySlackActionPayload(rawActionPayload, g.slackActionSigningSecret, time.Now())
+	if err != nil {
+		appLogger.Warnf(ctx, "Rejected Slack action payload, err=%+v", err)
+		writeSlackEphemeralResponse(w, "This Slack action is invalid or expired. Please open RISKEN and confirm the Finding.")
+		return
+	}
+
+	view, err := buildSlackActionModalView(actionPayload, rawActionPayload)
+	if err != nil {
+		appLogger.Warnf(ctx, "Failed to build Slack action modal view, err=%+v", err)
+		writeSlackEphemeralResponse(w, "Failed to open the Slack action form.")
+		return
+	}
+	if g.slackViewOpener == nil {
+		appLogger.Errorf(ctx, "Slack view opener is not configured")
+		writeSlackEphemeralResponse(w, "Slack action is not configured.")
+		return
+	}
+	if err := g.slackViewOpener.OpenView(ctx, interaction.TriggerID, view); err != nil {
+		appLogger.Errorf(ctx, "Failed to open Slack modal, err=%+v", err)
+		writeSlackEphemeralResponse(w, "Failed to open the Slack action form.")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func verifySlackRequestSignature(secret string, header http.Header, body []byte, now time.Time) error {
+	if secret == "" {
+		return errSlackSigningSecretNotConfigured
+	}
+	timestamp := header.Get("X-Slack-Request-Timestamp")
+	if timestamp == "" {
+		return errSlackRequestTimestampMissing
+	}
+	requestUnix, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return err
+	}
+	requestTime := time.Unix(requestUnix, 0)
+	if now.Sub(requestTime) > slackSignatureMaxAge || requestTime.Sub(now) > slackSignatureMaxAge {
+		return errSlackRequestTimestampExpired
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprintf(mac, "%s:%s:%s", slackSignatureVersion, timestamp, string(body))
+	want := slackSignatureVersion + "=" + hex.EncodeToString(mac.Sum(nil))
+	got := header.Get("X-Slack-Signature")
+	if !hmac.Equal([]byte(got), []byte(want)) {
+		return errSlackRequestSignatureInvalid
+	}
+	return nil
+}
+
+func parseSlackInteractionPayload(body []byte) (*slackInteractionPayload, string, error) {
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, "", err
+	}
+	rawPayload := values.Get("payload")
+	if rawPayload == "" {
+		return nil, "", errSlackInteractionPayloadMissing
+	}
+	var payload slackInteractionPayload
+	if err := json.Unmarshal([]byte(rawPayload), &payload); err != nil {
+		return nil, "", err
+	}
+	if payload.TriggerID == "" {
+		return nil, "", errSlackInteractionPayloadMissing
+	}
+	if len(payload.Actions) == 0 || payload.Actions[0].Value == "" {
+		return nil, "", errSlackActionPayloadMissing
+	}
+	return &payload, payload.Actions[0].Value, nil
+}
+
+func parseAndVerifySlackActionPayload(rawPayload, secret string, now time.Time) (*slackActionPayload, error) {
+	if secret == "" {
+		return nil, errSlackActionSigningSecretNotConfigured
+	}
+	var payload slackActionPayload
+	if err := json.Unmarshal([]byte(rawPayload), &payload); err != nil {
+		return nil, err
+	}
+	if payload.Action != slackActionPend && payload.Action != slackActionArchive {
+		return nil, errSlackActionPayloadInvalid
+	}
+	if payload.ProjectID == 0 || payload.FindingID == 0 || payload.IssuedAt == 0 || payload.ExpiresAt == 0 || payload.Signature == "" {
+		return nil, errSlackActionPayloadInvalid
+	}
+	if now.Unix() > payload.ExpiresAt {
+		return nil, errSlackActionPayloadExpired
+	}
+	want := signSlackActionPayload(payload, secret)
+	if !hmac.Equal([]byte(payload.Signature), []byte(want)) {
+		return nil, errSlackActionPayloadSignatureInvalid
+	}
+	return &payload, nil
+}
+
+func signSlackActionPayload(payload slackActionPayload, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprintf(mac, "%s:%d:%d:%d:%d", payload.Action, payload.ProjectID, payload.FindingID, payload.IssuedAt, payload.ExpiresAt)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func buildSlackActionModalView(payload *slackActionPayload, rawPayload string) (slackModalView, error) {
+	switch payload.Action {
+	case slackActionPend:
+		return buildPendSlackModalView(payload, rawPayload), nil
+	case slackActionArchive:
+		return buildArchiveSlackModalView(payload, rawPayload), nil
+	default:
+		return slackModalView{}, errSlackActionPayloadInvalid
+	}
+}
+
+func buildPendSlackModalView(payload *slackActionPayload, rawPayload string) slackModalView {
+	return slackModalView{
+		Type:            "modal",
+		CallbackID:      slackActionCallbackPend,
+		PrivateMetadata: rawPayload,
+		Title:           plainText("Pending Finding"),
+		Submit:          plainText("Submit"),
+		Close:           plainText("Cancel"),
+		Blocks: []slackBlockObject{
+			contextSection(payload),
+			{
+				Type:    "input",
+				BlockID: "pend_deadline",
+				Label:   &slackTextObject{Type: "plain_text", Text: "PEND deadline"},
+				Element: &slackElementObject{
+					Type:        "datepicker",
+					ActionID:    "date",
+					Placeholder: &slackTextObject{Type: "plain_text", Text: "Select a deadline"},
+				},
+			},
+			{
+				Type:     "input",
+				BlockID:  "pend_note",
+				Label:    &slackTextObject{Type: "plain_text", Text: "Note"},
+				Optional: true,
+				Element: &slackElementObject{
+					Type:        "plain_text_input",
+					ActionID:    "text",
+					Placeholder: &slackTextObject{Type: "plain_text", Text: "Add a note"},
+					Multiline:   true,
+				},
+			},
+		},
+	}
+}
+
+func buildArchiveSlackModalView(payload *slackActionPayload, rawPayload string) slackModalView {
+	return slackModalView{
+		Type:            "modal",
+		CallbackID:      slackActionCallbackArchive,
+		PrivateMetadata: rawPayload,
+		Title:           plainText("Archive Finding"),
+		Submit:          plainText("Submit"),
+		Close:           plainText("Cancel"),
+		Blocks: []slackBlockObject{
+			contextSection(payload),
+			{
+				Type:    "input",
+				BlockID: "archive_reason",
+				Label:   &slackTextObject{Type: "plain_text", Text: "Archive reason"},
+				Element: &slackElementObject{
+					Type:        "plain_text_input",
+					ActionID:    "text",
+					Placeholder: &slackTextObject{Type: "plain_text", Text: "Describe why this Finding can be archived"},
+					Multiline:   true,
+				},
+			},
+		},
+	}
+}
+
+func contextSection(payload *slackActionPayload) slackBlockObject {
+	return slackBlockObject{
+		Type: "section",
+		Text: &slackTextObject{
+			Type: "mrkdwn",
+			Text: fmt.Sprintf("*Project ID:* %d\n*Finding ID:* %d", payload.ProjectID, payload.FindingID),
+		},
+	}
+}
+
+func plainText(text string) slackTextObject {
+	return slackTextObject{
+		Type: "plain_text",
+		Text: text,
+	}
+}
+
+func writeSlackEphemeralResponse(w http.ResponseWriter, text string) {
+	body, err := json.Marshal(map[string]string{
+		"response_type": "ephemeral",
+		"text":          text,
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}

--- a/service_slack_test.go
+++ b/service_slack_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeSlackViewOpener struct {
+	triggerID string
+	view      slackModalView
+	err       error
+	calls     int
+}
+
+func (f *fakeSlackViewOpener) OpenView(ctx context.Context, triggerID string, view slackModalView) error {
+	f.triggerID = triggerID
+	f.view = view
+	f.calls++
+	return f.err
+}
+
+func TestVerifySlackRequestSignature(t *testing.T) {
+	now := time.Unix(1779721200, 0)
+	body := []byte("payload=test")
+	headers := signedSlackHeaders("slack-secret", body, now)
+
+	cases := []struct {
+		name    string
+		secret  string
+		headers http.Header
+		now     time.Time
+		wantErr bool
+	}{
+		{
+			name:    "OK",
+			secret:  "slack-secret",
+			headers: headers,
+			now:     now,
+		},
+		{
+			name:    "NG empty secret",
+			secret:  "",
+			headers: headers,
+			now:     now,
+			wantErr: true,
+		},
+		{
+			name:    "NG expired timestamp",
+			secret:  "slack-secret",
+			headers: headers,
+			now:     now.Add(slackSignatureMaxAge + time.Second),
+			wantErr: true,
+		},
+		{
+			name:   "NG invalid signature",
+			secret: "slack-secret",
+			headers: http.Header{
+				"X-Slack-Request-Timestamp": []string{fmt.Sprintf("%d", now.Unix())},
+				"X-Slack-Signature":         []string{"v0=invalid"},
+			},
+			now:     now,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := verifySlackRequestSignature(c.secret, c.headers, body, c.now)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("Unexpected error: got=%v wantErr=%t", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseAndVerifySlackActionPayload(t *testing.T) {
+	now := time.Unix(1779721200, 0)
+	payload := buildTestSlackActionPayload(slackActionPend, 1001, 123456, "action-secret", now)
+	rawPayload := mustJSON(t, payload)
+
+	got, err := parseAndVerifySlackActionPayload(rawPayload, "action-secret", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got.Action != slackActionPend || got.ProjectID != 1001 || got.FindingID != 123456 {
+		t.Fatalf("Unexpected payload: got=%+v", got)
+	}
+
+	expired := payload
+	expired.ExpiresAt = now.Add(-time.Second).Unix()
+	expired.Signature = signSlackActionPayload(expired, "action-secret")
+	if _, err := parseAndVerifySlackActionPayload(mustJSON(t, expired), "action-secret", now); err == nil {
+		t.Fatal("Expected expired payload to be rejected")
+	}
+
+	tampered := payload
+	tampered.ProjectID = 2002
+	if _, err := parseAndVerifySlackActionPayload(mustJSON(t, tampered), "action-secret", now); err == nil {
+		t.Fatal("Expected tampered payload to be rejected")
+	}
+
+	invalidAction := payload
+	invalidAction.Action = "delete"
+	invalidAction.Signature = signSlackActionPayload(invalidAction, "action-secret")
+	if _, err := parseAndVerifySlackActionPayload(mustJSON(t, invalidAction), "action-secret", now); err == nil {
+		t.Fatal("Expected invalid action to be rejected")
+	}
+}
+
+func TestSlackActionHandlerOpensPendModal(t *testing.T) {
+	now := time.Now()
+	opener := &fakeSlackViewOpener{}
+	svc := &gatewayService{
+		slackSigningSecret:       "slack-secret",
+		slackActionSigningSecret: "action-secret",
+		slackViewOpener:          opener,
+	}
+	rawActionPayload := mustJSON(t, buildTestSlackActionPayload(slackActionPend, 1001, 123456, "action-secret", now))
+	req := newSignedSlackActionRequest(t, "slack-secret", rawActionPayload, now)
+	rec := httptest.NewRecorder()
+
+	svc.slackActionHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Unexpected status: got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if opener.calls != 1 {
+		t.Fatalf("Unexpected Slack modal call count: got=%d", opener.calls)
+	}
+	if opener.triggerID != "trigger-1" {
+		t.Fatalf("Unexpected trigger ID: got=%s", opener.triggerID)
+	}
+	if opener.view.CallbackID != slackActionCallbackPend {
+		t.Fatalf("Unexpected callback ID: got=%s", opener.view.CallbackID)
+	}
+	if opener.view.PrivateMetadata != rawActionPayload {
+		t.Fatalf("Unexpected private metadata: got=%s", opener.view.PrivateMetadata)
+	}
+	if opener.view.Title.Text != "Pending Finding" {
+		t.Fatalf("Unexpected title: got=%s", opener.view.Title.Text)
+	}
+	if len(opener.view.Blocks) != 3 {
+		t.Fatalf("Unexpected block count: got=%d", len(opener.view.Blocks))
+	}
+	if opener.view.Blocks[1].BlockID != "pend_deadline" || opener.view.Blocks[1].Element.Type != "datepicker" {
+		t.Fatalf("Unexpected PEND deadline block: got=%+v", opener.view.Blocks[1])
+	}
+	if !opener.view.Blocks[2].Optional {
+		t.Fatalf("Expected PEND note to be optional: got=%+v", opener.view.Blocks[2])
+	}
+}
+
+func TestSlackActionHandlerOpensArchiveModal(t *testing.T) {
+	now := time.Now()
+	opener := &fakeSlackViewOpener{}
+	svc := &gatewayService{
+		slackSigningSecret:       "slack-secret",
+		slackActionSigningSecret: "action-secret",
+		slackViewOpener:          opener,
+	}
+	rawActionPayload := mustJSON(t, buildTestSlackActionPayload(slackActionArchive, 1001, 123456, "action-secret", now))
+	req := newSignedSlackActionRequest(t, "slack-secret", rawActionPayload, now)
+	rec := httptest.NewRecorder()
+
+	svc.slackActionHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Unexpected status: got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if opener.calls != 1 {
+		t.Fatalf("Unexpected Slack modal call count: got=%d", opener.calls)
+	}
+	if opener.view.CallbackID != slackActionCallbackArchive {
+		t.Fatalf("Unexpected callback ID: got=%s", opener.view.CallbackID)
+	}
+	if opener.view.Title.Text != "Archive Finding" {
+		t.Fatalf("Unexpected title: got=%s", opener.view.Title.Text)
+	}
+	if len(opener.view.Blocks) != 2 {
+		t.Fatalf("Unexpected block count: got=%d", len(opener.view.Blocks))
+	}
+	if opener.view.Blocks[1].BlockID != "archive_reason" || opener.view.Blocks[1].Optional {
+		t.Fatalf("Unexpected Archive reason block: got=%+v", opener.view.Blocks[1])
+	}
+}
+
+func TestSlackActionRouteOpensModalWithoutCSRFToken(t *testing.T) {
+	now := time.Now()
+	opener := &fakeSlackViewOpener{}
+	svc := &gatewayService{
+		slackSigningSecret:       "slack-secret",
+		slackActionSigningSecret: "action-secret",
+		slackViewOpener:          opener,
+	}
+	rawActionPayload := mustJSON(t, buildTestSlackActionPayload(slackActionPend, 1001, 123456, "action-secret", now))
+	req := newSignedSlackActionRequest(t, "slack-secret", rawActionPayload, now)
+	rec := httptest.NewRecorder()
+
+	newRouter(svc).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Unexpected status: got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if opener.calls != 1 {
+		t.Fatalf("Unexpected Slack modal call count: got=%d", opener.calls)
+	}
+}
+
+func TestSlackActionHandlerRejectsInvalidSlackSignature(t *testing.T) {
+	now := time.Now()
+	opener := &fakeSlackViewOpener{}
+	svc := &gatewayService{
+		slackSigningSecret:       "slack-secret",
+		slackActionSigningSecret: "action-secret",
+		slackViewOpener:          opener,
+	}
+	rawActionPayload := mustJSON(t, buildTestSlackActionPayload(slackActionPend, 1001, 123456, "action-secret", now))
+	req := newSignedSlackActionRequest(t, "wrong-secret", rawActionPayload, now)
+	rec := httptest.NewRecorder()
+
+	svc.slackActionHandler(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("Unexpected status: got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if opener.calls != 0 {
+		t.Fatalf("Unexpected Slack modal call count: got=%d", opener.calls)
+	}
+}
+
+func TestSlackActionHandlerRejectsInvalidActionPayload(t *testing.T) {
+	now := time.Now()
+	opener := &fakeSlackViewOpener{}
+	svc := &gatewayService{
+		slackSigningSecret:       "slack-secret",
+		slackActionSigningSecret: "action-secret",
+		slackViewOpener:          opener,
+	}
+	payload := buildTestSlackActionPayload(slackActionPend, 1001, 123456, "action-secret", now)
+	payload.FindingID = 999
+	req := newSignedSlackActionRequest(t, "slack-secret", mustJSON(t, payload), now)
+	rec := httptest.NewRecorder()
+
+	svc.slackActionHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Unexpected status: got=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid or expired") {
+		t.Fatalf("Unexpected response body: %s", rec.Body.String())
+	}
+	if opener.calls != 0 {
+		t.Fatalf("Unexpected Slack modal call count: got=%d", opener.calls)
+	}
+}
+
+func buildTestSlackActionPayload(action string, projectID uint32, findingID uint64, secret string, now time.Time) slackActionPayload {
+	payload := slackActionPayload{
+		Action:    action,
+		ProjectID: projectID,
+		FindingID: findingID,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(30 * 24 * time.Hour).Unix(),
+	}
+	payload.Signature = signSlackActionPayload(payload, secret)
+	return payload
+}
+
+func newSignedSlackActionRequest(t *testing.T, signingSecret, rawActionPayload string, now time.Time) *http.Request {
+	t.Helper()
+	payload := map[string]interface{}{
+		"type":       "interactive_message",
+		"trigger_id": "trigger-1",
+		"actions": []map[string]string{
+			{
+				"name":  "pend_finding",
+				"value": rawActionPayload,
+			},
+		},
+	}
+	rawInteractionPayload := mustJSON(t, payload)
+	body := url.Values{"payload": []string{rawInteractionPayload}}.Encode()
+	req := httptest.NewRequest(http.MethodPost, slackActionEndpointPath, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for key, values := range signedSlackHeaders(signingSecret, []byte(body), now) {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	return req
+}
+
+func signedSlackHeaders(secret string, body []byte, now time.Time) http.Header {
+	timestamp := fmt.Sprintf("%d", now.Unix())
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprintf(mac, "%s:%s:%s", slackSignatureVersion, timestamp, string(body))
+	return http.Header{
+		"X-Slack-Request-Timestamp": []string{timestamp},
+		"X-Slack-Signature":         []string{slackSignatureVersion + "=" + hex.EncodeToString(mac.Sum(nil))},
+	}
+}
+
+func mustJSON(t *testing.T, value interface{}) string {
+	t.Helper()
+	buf, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Failed to marshal JSON: %v", err)
+	}
+	return string(buf)
+}


### PR DESCRIPTION
## PRの概要

Slackアラートに追加されたPEND／Archiveボタンから、Gateway経由で操作用モーダルを開けるようにします。

Slackからのリクエスト署名と、Coreが生成したアクションペイロードの署名をそれぞれ検証し、改ざん・期限切れ・許可されていない操作を拒否します。

## 背景

### 【目的】

SlackのアラートからRISKENを開かず、安全にFindingのPEND／Archive操作を開始できるようにするためです。

### 【経緯】

Core側でSlackアラートへ操作ボタンを追加しても、Slackの操作リクエストを受け取り、モーダルを表示するGateway側の入口が必要でした。

また、Slack向けエンドポイントは通常のRISKENセッションやCSRFトークンを利用しないため、SlackおよびCoreから送られたデータであることを別の仕組みで検証する必要があります。

### 【経緯を踏まえた方針】

SlackのSigning Secretによるリクエスト検証と、Core・Gateway間で共有するSecretによるアクションペイロード検証を組み合わせます。

検証後、Bot Tokenを使用してPENDまたはArchive用のモーダルを開き、署名済みペイロードを後続処理へ引き継ぎます。

## 全体タスクにおける本PRの立ち位置

```mermaid
flowchart TD
    A["Core<br/>Slackアラートへ操作ボタンを付与"] --> B["Slack利用者<br/>PEND／Archiveボタンを選択"]
    B --> C["Gateway<br/>署名と有効期限を検証"]
    C --> D["Gateway<br/>操作用モーダルを表示"]
    D --> E["後続処理<br/>Findingの状態を更新"]

    A -.-> AStatus["Core側<br/>実装済み"]
    C -.-> CStatus["今回PR<br/>安全な受付口を追加"]
    D -.-> DStatus["今回PR<br/>モーダル表示を追加"]
    E -.-> EStatus["後続実装"]

    C:::current
    D:::current
    CStatus:::current
    DStatus:::current

    classDef current fill:#fff3cd,stroke:#d39e00,stroke-width:2px,color:#24292f;
```

## 修正点

| 変更点 | 内容 |
|---|---|
| Slack操作エンドポイント | `POST /api/v1/slack/actions`を追加 |
| Slack署名検証 | リクエスト署名とタイムスタンプを検証 |
| アクション検証 | Core生成ペイロードの署名、有効期限、操作種別を検証 |
| モーダル表示 | PEND期限・メモ、Archive理由の入力画面を追加 |
| 認証境界 | Slack操作エンドポイントをCSRF検証対象外に設定 |
| 安全対策 | Slack APIレスポンスの読込量とエラーログ出力を制限 |

## 重点レビューポイント

- SlackリクエストとCore生成ペイロードに対する二段階の署名検証が妥当かどうか
- CSRF検証対象外としたSlackエンドポイントが、Slack署名検証によって十分に保護されているかどうか
- 期限切れ、改ざん、不正な操作種別に対する拒否処理が適切かどうか
- Slack APIの異常応答に対するレスポンス読込量とログ出力の制限が十分かどうか

## 動作確認

以下を実施し、成功することを確認しました。

- `go test ./...`
- `make build`
- Docker Desktop Kubernetes上でGatewayが正常に起動すること
- `/healthz`がHTTP 200を返すこと
- 署名のない`POST /api/v1/slack/actions`がHTTP 401を返すこと
