### PR TITLE
[add]ghapp-resolve-token-router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c
+	github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c h1:lQYaUjw4EtJzesmmp6EmZaJH81gaxv1PbMySsrTfpOo=
-github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c/go.mod h1:e1qGlJqPJH+dqdwjPsB7ssrJ9wVTwtdYrwohNLl3TfA=
+github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c h1:RZmYcPdyxzgFhLZrPpzmStLUeghYwAGeM/i/3N/gh04=
+github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c/go.mod h1:0oGPPu+LrjnXNSJF73FlE5pJ60z1h/h5644TkERCElc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/router.go
+++ b/router.go
@@ -332,6 +332,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))
 					r.Post("/put-github-setting", svc.putGitHubSettingCodeHandler)
+					r.Post("/verify-github-app-installation", svc.verifyGitHubAppInstallationCodeHandler)
 					r.Post("/delete-github-setting", svc.deleteGitHubSettingCodeHandler)
 					r.Post("/put-gitleaks-setting", svc.putGitleaksSettingCodeHandler)
 					r.Post("/delete-gitleaks-setting", svc.deleteGitleaksSettingCodeHandler)

--- a/service_code_generated.go
+++ b/service_code_generated.go
@@ -72,6 +72,27 @@ func (g *gatewayService) putGitHubSettingCodeHandler(w http.ResponseWriter, r *h
 	writeResponse(ctx, w, http.StatusOK, map[string]interface{}{successJSONKey: resp})
 }
 
+func (g *gatewayService) verifyGitHubAppInstallationCodeHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	req := &code.VerifyGitHubAppInstallationRequest{}
+	if err := bind(req, r); err != nil {
+		appLogger.Warnf(ctx, "Failed to bind request, req=%s, err=%+v", "VerifyGitHubAppInstallationRequest", err)
+	}
+	if err := req.Validate(); err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]interface{}{errorJSONKey: err.Error()})
+		return
+	}
+	resp, err := g.codeClient.VerifyGitHubAppInstallation(ctx, req)
+	if err != nil {
+		if handleErr := handleGRPCError(ctx, w, err); handleErr != nil {
+			appLogger.Errorf(ctx, "HandleGRPCError: %+v", handleErr)
+			writeResponse(ctx, w, http.StatusInternalServerError, map[string]interface{}{errorJSONKey: "InternalServerError"})
+		}
+		return
+	}
+	writeResponse(ctx, w, http.StatusOK, map[string]interface{}{successJSONKey: resp})
+}
+
 func (g *gatewayService) deleteGitHubSettingCodeHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	req := &code.DeleteGitHubSettingRequest{}


### PR DESCRIPTION
gateway は generated proxy path で対応しました。VerifyGitHubAppInstallation の生成ハンドラを追加し、POST /code/verify-github-app-installation を project 認可配下にルーティングしています。
あわせて gateway の datasource-api 依存を新しい proto を含む版へ更新しました。