### PR TITLE
Add GitHub App OAuth gateway endpoints

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -366,6 +366,7 @@ func isHumanAccess(u *requestUser) bool {
 var ignoreURI4CSRF = []string{
 	"/healthz",
 	"/api/v1/signin",
+	githubAppOAuthCallbackPath,
 }
 
 func shouldVerifyCSRFTokenURI(uri string) bool {

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -778,6 +778,11 @@ func TestShouldVerifyCSRFTokenURI(t *testing.T) {
 			input: "/api/v1/signin/",
 			want:  false,
 		},
+		{
+			name:  "github app callback prefix is not ignored",
+			input: "/api/v1/code/github-app/oauth/callback-other",
+			want:  true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260612040932-64f7bc3dfccd
+	github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c
+	github.com/ca-risken/datasource-api v0.16.1-0.20260602032303-23af3f3c59c5
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260602032303-23af3f3c59c5
+	github.com/ca-risken/datasource-api v0.16.1-0.20260612040932-64f7bc3dfccd
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260602032303-23af3f3c59c5 h1:u9OzBY2qKcnkf705+4qwtSvu8vH7Uyo8UIWJPuwrs6c=
-github.com/ca-risken/datasource-api v0.16.1-0.20260602032303-23af3f3c59c5/go.mod h1:C2gc9HIrWMBn9WUDvtrW3hZkvngyHqTmiyaHWRMWeDw=
+github.com/ca-risken/datasource-api v0.16.1-0.20260612040932-64f7bc3dfccd h1:fr1jpRQD3+pnuUl/xugT1SVFQjw+2vTAe8Qma31QUCk=
+github.com/ca-risken/datasource-api v0.16.1-0.20260612040932-64f7bc3dfccd/go.mod h1:xktE2epQWUc2GZom/b09CxMWk62cosU90R4dV7zGWo0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260612040932-64f7bc3dfccd h1:fr1jpRQD3+pnuUl/xugT1SVFQjw+2vTAe8Qma31QUCk=
-github.com/ca-risken/datasource-api v0.16.1-0.20260612040932-64f7bc3dfccd/go.mod h1:xktE2epQWUc2GZom/b09CxMWk62cosU90R4dV7zGWo0=
+github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0 h1:vtyk9VlwbfQzcwxQQCQXMlxKH82ocwDVNgSxFy47w3o=
+github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0/go.mod h1:xktE2epQWUc2GZom/b09CxMWk62cosU90R4dV7zGWo0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c h1:RZmYcPdyxzgFhLZrPpzmStLUeghYwAGeM/i/3N/gh04=
-github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c/go.mod h1:0oGPPu+LrjnXNSJF73FlE5pJ60z1h/h5644TkERCElc=
+github.com/ca-risken/datasource-api v0.16.1-0.20260602032303-23af3f3c59c5 h1:u9OzBY2qKcnkf705+4qwtSvu8vH7Uyo8UIWJPuwrs6c=
+github.com/ca-risken/datasource-api v0.16.1-0.20260602032303-23af3f3c59c5/go.mod h1:C2gc9HIrWMBn9WUDvtrW3hZkvngyHqTmiyaHWRMWeDw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/main.go
+++ b/main.go
@@ -42,17 +42,18 @@ type AppConfig struct {
 	UserIdpKey         string   `split_words:"true" default:"preferred_username"`
 	Region             string   `default:"ap-northeast-1"`
 
-	CoreAddr               string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
-	DataSourceAPISvcAddr   string `required:"true" split_words:"true" default:"datasource-api.datasource.svc.cluster.local:8081"`
-	MaxRequestBodyBytes    int64  `split_words:"true" default:"1048576"`
-	ReadHeaderTimeoutSec   int    `split_words:"true" default:"5"`
-	ReadTimeoutSec         int    `split_words:"true" default:"30"`
-	WriteTimeoutSec        int    `split_words:"true" default:"30"`
-	IdleTimeoutSec         int    `split_words:"true" default:"120"`
-	MaxHeaderBytes         int    `split_words:"true" default:"1048576"`
-	GithubAppSlug          string `split_words:"true"`
-	GithubAppOAuthClientID string `split_words:"true"`
-	GithubAppStateSecret   string `split_words:"true"`
+	CoreAddr                  string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
+	DataSourceAPISvcAddr      string `required:"true" split_words:"true" default:"datasource-api.datasource.svc.cluster.local:8081"`
+	MaxRequestBodyBytes       int64  `split_words:"true" default:"1048576"`
+	ReadHeaderTimeoutSec      int    `split_words:"true" default:"5"`
+	ReadTimeoutSec            int    `split_words:"true" default:"30"`
+	WriteTimeoutSec           int    `split_words:"true" default:"30"`
+	IdleTimeoutSec            int    `split_words:"true" default:"120"`
+	MaxHeaderBytes            int    `split_words:"true" default:"1048576"`
+	GithubAppSlug             string `split_words:"true"`
+	GithubAppOAuthClientID    string `split_words:"true"`
+	GithubAppOAuthRedirectURL string `split_words:"true"`
+	GithubAppStateSecret      string `split_words:"true"`
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ type AppConfig struct {
 	WriteTimeoutSec        int    `split_words:"true" default:"30"`
 	IdleTimeoutSec         int    `split_words:"true" default:"120"`
 	MaxHeaderBytes         int    `split_words:"true" default:"1048576"`
+	GithubAppSlug          string `split_words:"true"`
 	GithubAppOAuthClientID string `split_words:"true"`
 	GithubAppStateSecret   string `split_words:"true"`
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ type AppConfig struct {
 	WriteTimeoutSec      int    `split_words:"true" default:"30"`
 	IdleTimeoutSec       int    `split_words:"true" default:"120"`
 	MaxHeaderBytes       int    `split_words:"true" default:"1048576"`
-	GithubAppInstallURL  string `split_words:"true"`
+	GithubAppSlug        string `split_words:"true"`
 	GithubAppStateSecret string `split_words:"true"`
 }
 

--- a/main.go
+++ b/main.go
@@ -50,6 +50,8 @@ type AppConfig struct {
 	WriteTimeoutSec      int    `split_words:"true" default:"30"`
 	IdleTimeoutSec       int    `split_words:"true" default:"120"`
 	MaxHeaderBytes       int    `split_words:"true" default:"1048576"`
+	GithubAppInstallURL  string `split_words:"true"`
+	GithubAppStateSecret string `split_words:"true"`
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -42,16 +42,16 @@ type AppConfig struct {
 	UserIdpKey         string   `split_words:"true" default:"preferred_username"`
 	Region             string   `default:"ap-northeast-1"`
 
-	CoreAddr             string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
-	DataSourceAPISvcAddr string `required:"true" split_words:"true" default:"datasource-api.datasource.svc.cluster.local:8081"`
-	MaxRequestBodyBytes  int64  `split_words:"true" default:"1048576"`
-	ReadHeaderTimeoutSec int    `split_words:"true" default:"5"`
-	ReadTimeoutSec       int    `split_words:"true" default:"30"`
-	WriteTimeoutSec      int    `split_words:"true" default:"30"`
-	IdleTimeoutSec       int    `split_words:"true" default:"120"`
-	MaxHeaderBytes       int    `split_words:"true" default:"1048576"`
-	GithubAppSlug        string `split_words:"true"`
-	GithubAppStateSecret string `split_words:"true"`
+	CoreAddr               string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
+	DataSourceAPISvcAddr   string `required:"true" split_words:"true" default:"datasource-api.datasource.svc.cluster.local:8081"`
+	MaxRequestBodyBytes    int64  `split_words:"true" default:"1048576"`
+	ReadHeaderTimeoutSec   int    `split_words:"true" default:"5"`
+	ReadTimeoutSec         int    `split_words:"true" default:"30"`
+	WriteTimeoutSec        int    `split_words:"true" default:"30"`
+	IdleTimeoutSec         int    `split_words:"true" default:"120"`
+	MaxHeaderBytes         int    `split_words:"true" default:"1048576"`
+	GithubAppOAuthClientID string `split_words:"true"`
+	GithubAppStateSecret   string `split_words:"true"`
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -93,7 +93,26 @@ func TestValidateGatewayConfig(t *testing.T) {
 				GithubAppOAuthRedirectURL: "/api/v1/code/github-app/oauth/callback",
 				GithubAppStateSecret:      "12345678901234567890123456789012",
 			},
-			wantErrMsg: "github app oauth redirect url must be an absolute http or https URL",
+			wantErrMsg: "github app oauth redirect url must be an absolute URL",
+		},
+		{
+			name: "github app enabled with local http redirect url",
+			conf: &AppConfig{
+				EnvName:                   "local",
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "http://localhost:8080/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+		},
+		{
+			name: "github app enabled with production http redirect url",
+			conf: &AppConfig{
+				EnvName:                   "prod",
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "http://localhost:8080/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+			wantErrMsg: "github app oauth redirect url must use https except local localhost",
 		},
 		{
 			name: "github app enabled with slash slug",

--- a/main_test.go
+++ b/main_test.go
@@ -53,38 +53,22 @@ func TestValidateGatewayConfig(t *testing.T) {
 			conf: &AppConfig{
 				GithubAppStateSecret: "short",
 			},
-			wantErrMsg: "github app state secret must be empty or at least 32 bytes when github app slug is not configured",
+			wantErrMsg: "github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured",
 		},
 		{
 			name: "github app enabled with strong state secret",
 			conf: &AppConfig{
-				GithubAppSlug:        "risken",
-				GithubAppStateSecret: "12345678901234567890123456789012",
+				GithubAppOAuthClientID: "Iv1.0123456789abcdef",
+				GithubAppStateSecret:   "12345678901234567890123456789012",
 			},
 		},
 		{
 			name: "github app enabled with short state secret",
 			conf: &AppConfig{
-				GithubAppSlug:        "risken",
-				GithubAppStateSecret: "short",
+				GithubAppOAuthClientID: "Iv1.0123456789abcdef",
+				GithubAppStateSecret:   "short",
 			},
-			wantErrMsg: "github app state secret must be at least 32 bytes when github app slug is configured",
-		},
-		{
-			name: "github app enabled with slash slug",
-			conf: &AppConfig{
-				GithubAppSlug:        "owner/risken",
-				GithubAppStateSecret: "12345678901234567890123456789012",
-			},
-			wantErrMsg: "github app slug is invalid",
-		},
-		{
-			name: "github app enabled with empty-like slug",
-			conf: &AppConfig{
-				GithubAppSlug:        "-risken",
-				GithubAppStateSecret: "12345678901234567890123456789012",
-			},
-			wantErrMsg: "github app slug is invalid",
+			wantErrMsg: "github app state secret must be at least 32 bytes when github app oauth client id is configured",
 		},
 	}
 	for _, c := range cases {

--- a/main_test.go
+++ b/main_test.go
@@ -58,7 +58,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 		{
 			name: "github app enabled with strong state secret",
 			conf: &AppConfig{
-				GithubAppOAuthClientID: "Iv1.0123456789abcdef",
+				GithubAppOAuthClientID: "test-github-app-client-id",
 				GithubAppStateSecret:   "12345678901234567890123456789012",
 			},
 		},
@@ -71,7 +71,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 		{
 			name: "github app enabled with short state secret",
 			conf: &AppConfig{
-				GithubAppOAuthClientID: "Iv1.0123456789abcdef",
+				GithubAppOAuthClientID: "test-github-app-client-id",
 				GithubAppStateSecret:   "short",
 			},
 			wantErrMsg: "github app state secret must be at least 32 bytes when github app oauth client id is configured",

--- a/main_test.go
+++ b/main_test.go
@@ -53,38 +53,38 @@ func TestValidateGatewayConfig(t *testing.T) {
 			conf: &AppConfig{
 				GithubAppStateSecret: "short",
 			},
-			wantErrMsg: "github app state secret must be empty or at least 32 bytes when github app install url is not configured",
+			wantErrMsg: "github app state secret must be empty or at least 32 bytes when github app slug is not configured",
 		},
 		{
 			name: "github app enabled with strong state secret",
 			conf: &AppConfig{
-				GithubAppInstallURL:  "https://github.com/apps/risken/installations/new",
+				GithubAppSlug:        "risken",
 				GithubAppStateSecret: "12345678901234567890123456789012",
 			},
 		},
 		{
 			name: "github app enabled with short state secret",
 			conf: &AppConfig{
-				GithubAppInstallURL:  "https://github.com/apps/risken/installations/new",
+				GithubAppSlug:        "risken",
 				GithubAppStateSecret: "short",
 			},
-			wantErrMsg: "github app state secret must be at least 32 bytes when github app install url is configured",
+			wantErrMsg: "github app state secret must be at least 32 bytes when github app slug is configured",
 		},
 		{
-			name: "github app enabled with http install url",
+			name: "github app enabled with slash slug",
 			conf: &AppConfig{
-				GithubAppInstallURL:  "http://github.com/apps/risken/installations/new",
+				GithubAppSlug:        "owner/risken",
 				GithubAppStateSecret: "12345678901234567890123456789012",
 			},
-			wantErrMsg: "github app install url must be https",
+			wantErrMsg: "github app slug is invalid",
 		},
 		{
-			name: "github app enabled with relative install url",
+			name: "github app enabled with empty-like slug",
 			conf: &AppConfig{
-				GithubAppInstallURL:  "/apps/risken/installations/new",
+				GithubAppSlug:        "-risken",
 				GithubAppStateSecret: "12345678901234567890123456789012",
 			},
-			wantErrMsg: "github app install url must be https",
+			wantErrMsg: "github app slug is invalid",
 		},
 	}
 	for _, c := range cases {

--- a/main_test.go
+++ b/main_test.go
@@ -37,3 +37,42 @@ func TestNewHTTPServer(t *testing.T) {
 		t.Fatalf("unexpected max header bytes: %d", server.MaxHeaderBytes)
 	}
 }
+
+func TestValidateGatewayConfig(t *testing.T) {
+	cases := []struct {
+		name      string
+		conf      *AppConfig
+		wantError bool
+	}{
+		{
+			name: "github app disabled",
+			conf: &AppConfig{},
+		},
+		{
+			name: "github app enabled with strong state secret",
+			conf: &AppConfig{
+				GithubAppInstallURL:  "https://github.com/apps/risken/installations/new",
+				GithubAppStateSecret: "12345678901234567890123456789012",
+			},
+		},
+		{
+			name: "github app enabled with short state secret",
+			conf: &AppConfig{
+				GithubAppInstallURL:  "https://github.com/apps/risken/installations/new",
+				GithubAppStateSecret: "short",
+			},
+			wantError: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateGatewayConfig(c.conf)
+			if c.wantError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !c.wantError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -58,8 +58,9 @@ func TestValidateGatewayConfig(t *testing.T) {
 		{
 			name: "github app enabled with strong state secret",
 			conf: &AppConfig{
-				GithubAppOAuthClientID: "test-github-app-client-id",
-				GithubAppStateSecret:   "12345678901234567890123456789012",
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "https://risken.example/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
 			},
 		},
 		{
@@ -71,10 +72,28 @@ func TestValidateGatewayConfig(t *testing.T) {
 		{
 			name: "github app enabled with short state secret",
 			conf: &AppConfig{
-				GithubAppOAuthClientID: "test-github-app-client-id",
-				GithubAppStateSecret:   "short",
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "https://risken.example/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "short",
 			},
 			wantErrMsg: "github app state secret must be at least 32 bytes when github app oauth client id is configured",
+		},
+		{
+			name: "github app enabled without redirect url",
+			conf: &AppConfig{
+				GithubAppOAuthClientID: "test-github-app-client-id",
+				GithubAppStateSecret:   "12345678901234567890123456789012",
+			},
+			wantErrMsg: "github app oauth redirect url is required when github app oauth client id is configured",
+		},
+		{
+			name: "github app enabled with relative redirect url",
+			conf: &AppConfig{
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+			wantErrMsg: "github app oauth redirect url must be an absolute http or https URL",
 		},
 		{
 			name: "github app enabled with slash slug",

--- a/main_test.go
+++ b/main_test.go
@@ -63,12 +63,25 @@ func TestValidateGatewayConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "github app install url enabled with slug only",
+			conf: &AppConfig{
+				GithubAppSlug: "risken",
+			},
+		},
+		{
 			name: "github app enabled with short state secret",
 			conf: &AppConfig{
 				GithubAppOAuthClientID: "Iv1.0123456789abcdef",
 				GithubAppStateSecret:   "short",
 			},
 			wantErrMsg: "github app state secret must be at least 32 bytes when github app oauth client id is configured",
+		},
+		{
+			name: "github app enabled with slash slug",
+			conf: &AppConfig{
+				GithubAppSlug: "owner/risken",
+			},
+			wantErrMsg: "github app slug is invalid",
 		},
 	}
 	for _, c := range cases {

--- a/main_test.go
+++ b/main_test.go
@@ -49,6 +49,13 @@ func TestValidateGatewayConfig(t *testing.T) {
 			conf: &AppConfig{},
 		},
 		{
+			name: "github app disabled with short state secret",
+			conf: &AppConfig{
+				GithubAppStateSecret: "short",
+			},
+			wantError: true,
+		},
+		{
 			name: "github app enabled with strong state secret",
 			conf: &AppConfig{
 				GithubAppInstallURL:  "https://github.com/apps/risken/installations/new",

--- a/main_test.go
+++ b/main_test.go
@@ -63,6 +63,22 @@ func TestValidateGatewayConfig(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name: "github app enabled with http install url",
+			conf: &AppConfig{
+				GithubAppInstallURL:  "http://github.com/apps/risken/installations/new",
+				GithubAppStateSecret: "12345678901234567890123456789012",
+			},
+			wantError: true,
+		},
+		{
+			name: "github app enabled with relative install url",
+			conf: &AppConfig{
+				GithubAppInstallURL:  "/apps/risken/installations/new",
+				GithubAppStateSecret: "12345678901234567890123456789012",
+			},
+			wantError: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -40,9 +40,9 @@ func TestNewHTTPServer(t *testing.T) {
 
 func TestValidateGatewayConfig(t *testing.T) {
 	cases := []struct {
-		name      string
-		conf      *AppConfig
-		wantError bool
+		name       string
+		conf       *AppConfig
+		wantErrMsg string
 	}{
 		{
 			name: "github app disabled",
@@ -53,7 +53,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 			conf: &AppConfig{
 				GithubAppStateSecret: "short",
 			},
-			wantError: true,
+			wantErrMsg: "github app state secret must be empty or at least 32 bytes when github app install url is not configured",
 		},
 		{
 			name: "github app enabled with strong state secret",
@@ -68,7 +68,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 				GithubAppInstallURL:  "https://github.com/apps/risken/installations/new",
 				GithubAppStateSecret: "short",
 			},
-			wantError: true,
+			wantErrMsg: "github app state secret must be at least 32 bytes when github app install url is configured",
 		},
 		{
 			name: "github app enabled with http install url",
@@ -76,7 +76,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 				GithubAppInstallURL:  "http://github.com/apps/risken/installations/new",
 				GithubAppStateSecret: "12345678901234567890123456789012",
 			},
-			wantError: true,
+			wantErrMsg: "github app install url must be https",
 		},
 		{
 			name: "github app enabled with relative install url",
@@ -84,17 +84,20 @@ func TestValidateGatewayConfig(t *testing.T) {
 				GithubAppInstallURL:  "/apps/risken/installations/new",
 				GithubAppStateSecret: "12345678901234567890123456789012",
 			},
-			wantError: true,
+			wantErrMsg: "github app install url must be https",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			err := validateGatewayConfig(c.conf)
-			if c.wantError && err == nil {
+			if c.wantErrMsg != "" && err == nil {
 				t.Fatal("expected error but got nil")
 			}
-			if !c.wantError && err != nil {
+			if c.wantErrMsg == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if c.wantErrMsg != "" && err.Error() != c.wantErrMsg {
+				t.Fatalf("unexpected error. want=%q, got=%q", c.wantErrMsg, err.Error())
 			}
 		})
 	}

--- a/router.go
+++ b/router.go
@@ -330,7 +330,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(svc.authzWithProject)
 				r.Get("/list-github-setting", svc.listGitHubSettingCodeHandler)
 				r.Get("/list-gitleaks-cache", svc.listGitleaksCacheCodeHandler)
-				r.Get("/github-app/install-url", svc.githubAppInstallURLHandler)
+				r.Get("/github-app/oauth-start", svc.githubAppOAuthStartHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))
 					r.Post("/put-github-setting", svc.putGitHubSettingCodeHandler)

--- a/router.go
+++ b/router.go
@@ -324,11 +324,13 @@ func newRouter(svc *gatewayService) *chi.Mux {
 			r.Group(func(r chi.Router) {
 				// project any
 				r.Get("/list-datasource", svc.listDataSourceCodeHandler)
+				r.Get("/github-app/oauth/callback", svc.githubAppOAuthCallbackHandler)
 			})
 			r.Group(func(r chi.Router) {
 				r.Use(svc.authzWithProject)
 				r.Get("/list-github-setting", svc.listGitHubSettingCodeHandler)
 				r.Get("/list-gitleaks-cache", svc.listGitleaksCacheCodeHandler)
+				r.Get("/github-app/install-url", svc.githubAppInstallURLHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))
 					r.Post("/put-github-setting", svc.putGitHubSettingCodeHandler)

--- a/router.go
+++ b/router.go
@@ -330,6 +330,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(svc.authzWithProject)
 				r.Get("/list-github-setting", svc.listGitHubSettingCodeHandler)
 				r.Get("/list-gitleaks-cache", svc.listGitleaksCacheCodeHandler)
+				r.Get("/github-app/install-url", svc.githubAppInstallURLHandler)
 				r.Get("/github-app/oauth-start", svc.githubAppOAuthStartHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))

--- a/service.go
+++ b/service.go
@@ -33,6 +33,8 @@ import (
 const (
 	successJSONKey = "data"
 	errorJSONKey   = "error"
+
+	minGitHubAppStateSecretBytes = 32
 )
 
 type gatewayService struct {
@@ -66,6 +68,9 @@ type gatewayService struct {
 func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
 	if conf.Debug {
 		appLogger.Level(logging.DebugLevel)
+	}
+	if err := validateGatewayConfig(conf); err != nil {
+		return nil, err
 	}
 
 	coreConn, err := getGRPCConn(ctx, conf.CoreAddr)
@@ -105,6 +110,16 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		claimsClient:         newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
 		datasourceClient:     datasource.NewDataSourceServiceClient(datasourceConn),
 	}, nil
+}
+
+func validateGatewayConfig(conf *AppConfig) error {
+	if conf.GithubAppInstallURL == "" {
+		return nil
+	}
+	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
+		return errors.New("github app state secret must be at least 32 bytes when github app install url is configured")
+	}
+	return nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/service.go
+++ b/service.go
@@ -44,7 +44,7 @@ type gatewayService struct {
 	oidcDataHeader       string
 	sessionCookieName    []string
 	sessionTimeoutSec    int
-	githubAppSlug        string
+	githubAppClientID    string
 	githubAppStateSecret string
 	findingClient        finding.FindingServiceClient
 	iamClient            iam.IAMServiceClient
@@ -90,7 +90,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		oidcDataHeader:       conf.OidcDataHeader,
 		sessionCookieName:    conf.SessionCookieName,
 		sessionTimeoutSec:    conf.SessionTimeoutSec,
-		githubAppSlug:        conf.GithubAppSlug,
+		githubAppClientID:    conf.GithubAppOAuthClientID,
 		githubAppStateSecret: conf.GithubAppStateSecret,
 		findingClient:        finding.NewFindingServiceClient(coreConn),
 		iamClient:            iam.NewIAMServiceClient(coreConn),
@@ -113,20 +113,17 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 }
 
 func validateGatewayConfig(conf *AppConfig) error {
-	if conf.GithubAppSlug == "" {
+	if conf.GithubAppOAuthClientID == "" {
 		if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-			return errors.New("github app state secret must be empty or at least 32 bytes when github app slug is not configured")
+			return errors.New("github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured")
 		}
 		return nil
 	}
-	if err := validateGitHubAppSlug(conf.GithubAppSlug); err != nil {
-		return err
-	}
 	if conf.GithubAppStateSecret == "" {
-		return errors.New("github app state secret is required when github app slug is configured")
+		return errors.New("github app state secret is required when github app oauth client id is configured")
 	}
 	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-		return errors.New("github app state secret must be at least 32 bytes when github app slug is configured")
+		return errors.New("github app state secret must be at least 32 bytes when github app oauth client id is configured")
 	}
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -113,6 +113,9 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 }
 
 func validateGatewayConfig(conf *AppConfig) error {
+	if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
+		return errors.New("github app state secret must be at least 32 bytes")
+	}
 	if conf.GithubAppInstallURL == "" {
 		return nil
 	}
@@ -120,7 +123,7 @@ func validateGatewayConfig(conf *AppConfig) error {
 		return err
 	}
 	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-		return errors.New("github app state secret must be at least 32 bytes when github app install url is configured")
+		return errors.New("github app state secret must be at least 32 bytes")
 	}
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/ca-risken/common/pkg/logging"
@@ -46,6 +47,8 @@ type gatewayService struct {
 	sessionTimeoutSec    int
 	githubAppSlug        string
 	githubAppStateSecret string
+	githubAppStateMu     sync.Mutex
+	githubAppUsedStates  map[string]int64
 	findingClient        finding.FindingServiceClient
 	iamClient            iam.IAMServiceClient
 	projectClient        project.ProjectServiceClient

--- a/service.go
+++ b/service.go
@@ -46,6 +46,7 @@ type gatewayService struct {
 	sessionTimeoutSec    int
 	githubAppSlug        string
 	githubAppClientID    string
+	githubAppRedirectURL string
 	githubAppStateSecret string
 	findingClient        finding.FindingServiceClient
 	iamClient            iam.IAMServiceClient
@@ -93,6 +94,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		sessionTimeoutSec:    conf.SessionTimeoutSec,
 		githubAppSlug:        conf.GithubAppSlug,
 		githubAppClientID:    conf.GithubAppOAuthClientID,
+		githubAppRedirectURL: conf.GithubAppOAuthRedirectURL,
 		githubAppStateSecret: conf.GithubAppStateSecret,
 		findingClient:        finding.NewFindingServiceClient(coreConn),
 		iamClient:            iam.NewIAMServiceClient(coreConn),
@@ -125,6 +127,12 @@ func validateGatewayConfig(conf *AppConfig) error {
 			return errors.New("github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured")
 		}
 		return nil
+	}
+	if conf.GithubAppOAuthRedirectURL == "" {
+		return errors.New("github app oauth redirect url is required when github app oauth client id is configured")
+	}
+	if _, err := validateGitHubAppOAuthRedirectURL(conf.GithubAppOAuthRedirectURL); err != nil {
+		return err
 	}
 	if conf.GithubAppStateSecret == "" {
 		return errors.New("github app state secret is required when github app oauth client id is configured")

--- a/service.go
+++ b/service.go
@@ -44,6 +44,7 @@ type gatewayService struct {
 	oidcDataHeader       string
 	sessionCookieName    []string
 	sessionTimeoutSec    int
+	githubAppSlug        string
 	githubAppClientID    string
 	githubAppStateSecret string
 	findingClient        finding.FindingServiceClient
@@ -90,6 +91,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		oidcDataHeader:       conf.OidcDataHeader,
 		sessionCookieName:    conf.SessionCookieName,
 		sessionTimeoutSec:    conf.SessionTimeoutSec,
+		githubAppSlug:        conf.GithubAppSlug,
 		githubAppClientID:    conf.GithubAppOAuthClientID,
 		githubAppStateSecret: conf.GithubAppStateSecret,
 		findingClient:        finding.NewFindingServiceClient(coreConn),
@@ -113,6 +115,11 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 }
 
 func validateGatewayConfig(conf *AppConfig) error {
+	if conf.GithubAppSlug != "" {
+		if err := validateGitHubAppSlug(conf.GithubAppSlug); err != nil {
+			return err
+		}
+	}
 	if conf.GithubAppOAuthClientID == "" {
 		if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
 			return errors.New("github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured")

--- a/service.go
+++ b/service.go
@@ -44,7 +44,7 @@ type gatewayService struct {
 	oidcDataHeader       string
 	sessionCookieName    []string
 	sessionTimeoutSec    int
-	githubAppInstallURL  string
+	githubAppSlug        string
 	githubAppStateSecret string
 	findingClient        finding.FindingServiceClient
 	iamClient            iam.IAMServiceClient
@@ -90,7 +90,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		oidcDataHeader:       conf.OidcDataHeader,
 		sessionCookieName:    conf.SessionCookieName,
 		sessionTimeoutSec:    conf.SessionTimeoutSec,
-		githubAppInstallURL:  conf.GithubAppInstallURL,
+		githubAppSlug:        conf.GithubAppSlug,
 		githubAppStateSecret: conf.GithubAppStateSecret,
 		findingClient:        finding.NewFindingServiceClient(coreConn),
 		iamClient:            iam.NewIAMServiceClient(coreConn),
@@ -113,20 +113,20 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 }
 
 func validateGatewayConfig(conf *AppConfig) error {
-	if conf.GithubAppInstallURL == "" {
+	if conf.GithubAppSlug == "" {
 		if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-			return errors.New("github app state secret must be empty or at least 32 bytes when github app install url is not configured")
+			return errors.New("github app state secret must be empty or at least 32 bytes when github app slug is not configured")
 		}
 		return nil
 	}
-	if _, err := parseGitHubAppInstallURL(conf.GithubAppInstallURL); err != nil {
+	if err := validateGitHubAppSlug(conf.GithubAppSlug); err != nil {
 		return err
 	}
 	if conf.GithubAppStateSecret == "" {
-		return errors.New("github app state secret is required when github app install url is configured")
+		return errors.New("github app state secret is required when github app slug is configured")
 	}
 	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-		return errors.New("github app state secret must be at least 32 bytes when github app install url is configured")
+		return errors.New("github app state secret must be at least 32 bytes when github app slug is configured")
 	}
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -36,29 +36,31 @@ const (
 )
 
 type gatewayService struct {
-	envName            string
-	port               string
-	uidHeader          string
-	oidcDataHeader     string
-	sessionCookieName  []string
-	sessionTimeoutSec  int
-	findingClient      finding.FindingServiceClient
-	iamClient          iam.IAMServiceClient
-	projectClient      project.ProjectServiceClient
-	alertClient        alert.AlertServiceClient
-	reportClient       report.ReportServiceClient
-	organizationClient organization.OrganizationServiceClient
-	org_iamClient      org_iam.OrgIAMServiceClient
-	org_alertClient    org_alert.OrgAlertServiceClient
-	awsClient          aws.AWSServiceClient
-	osintClient        osint.OsintServiceClient
-	diagnosisClient    diagnosis.DiagnosisServiceClient
-	codeClient         code.CodeServiceClient
-	googleClient       google.GoogleServiceClient
-	azureClient        azure.AzureServiceClient
-	aiClient           ai.AIServiceClient
-	claimsClient       claimsInterface
-	datasourceClient   datasource.DataSourceServiceClient
+	envName              string
+	port                 string
+	uidHeader            string
+	oidcDataHeader       string
+	sessionCookieName    []string
+	sessionTimeoutSec    int
+	githubAppInstallURL  string
+	githubAppStateSecret string
+	findingClient        finding.FindingServiceClient
+	iamClient            iam.IAMServiceClient
+	projectClient        project.ProjectServiceClient
+	alertClient          alert.AlertServiceClient
+	reportClient         report.ReportServiceClient
+	organizationClient   organization.OrganizationServiceClient
+	org_iamClient        org_iam.OrgIAMServiceClient
+	org_alertClient      org_alert.OrgAlertServiceClient
+	awsClient            aws.AWSServiceClient
+	osintClient          osint.OsintServiceClient
+	diagnosisClient      diagnosis.DiagnosisServiceClient
+	codeClient           code.CodeServiceClient
+	googleClient         google.GoogleServiceClient
+	azureClient          azure.AzureServiceClient
+	aiClient             ai.AIServiceClient
+	claimsClient         claimsInterface
+	datasourceClient     datasource.DataSourceServiceClient
 }
 
 func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
@@ -77,29 +79,31 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		return nil, err
 	}
 	return &gatewayService{
-		envName:            conf.EnvName,
-		port:               conf.Port,
-		uidHeader:          conf.UserIdentityHeader,
-		oidcDataHeader:     conf.OidcDataHeader,
-		sessionCookieName:  conf.SessionCookieName,
-		sessionTimeoutSec:  conf.SessionTimeoutSec,
-		findingClient:      finding.NewFindingServiceClient(coreConn),
-		iamClient:          iam.NewIAMServiceClient(coreConn),
-		projectClient:      project.NewProjectServiceClient(coreConn),
-		alertClient:        alert.NewAlertServiceClient(coreConn),
-		reportClient:       report.NewReportServiceClient(coreConn),
-		organizationClient: organization.NewOrganizationServiceClient(coreConn),
-		org_iamClient:      org_iam.NewOrgIAMServiceClient(coreConn),
-		org_alertClient:    org_alert.NewOrgAlertServiceClient(coreConn),
-		awsClient:          aws.NewAWSServiceClient(datasourceConn),
-		osintClient:        osint.NewOsintServiceClient(datasourceConn),
-		diagnosisClient:    diagnosis.NewDiagnosisServiceClient(datasourceConn),
-		codeClient:         code.NewCodeServiceClient(datasourceConn),
-		googleClient:       google.NewGoogleServiceClient(datasourceConn),
-		azureClient:        azure.NewAzureServiceClient(datasourceConn),
-		aiClient:           ai.NewAIServiceClient(coreConn),
-		claimsClient:       newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
-		datasourceClient:   datasource.NewDataSourceServiceClient(datasourceConn),
+		envName:              conf.EnvName,
+		port:                 conf.Port,
+		uidHeader:            conf.UserIdentityHeader,
+		oidcDataHeader:       conf.OidcDataHeader,
+		sessionCookieName:    conf.SessionCookieName,
+		sessionTimeoutSec:    conf.SessionTimeoutSec,
+		githubAppInstallURL:  conf.GithubAppInstallURL,
+		githubAppStateSecret: conf.GithubAppStateSecret,
+		findingClient:        finding.NewFindingServiceClient(coreConn),
+		iamClient:            iam.NewIAMServiceClient(coreConn),
+		projectClient:        project.NewProjectServiceClient(coreConn),
+		alertClient:          alert.NewAlertServiceClient(coreConn),
+		reportClient:         report.NewReportServiceClient(coreConn),
+		organizationClient:   organization.NewOrganizationServiceClient(coreConn),
+		org_iamClient:        org_iam.NewOrgIAMServiceClient(coreConn),
+		org_alertClient:      org_alert.NewOrgAlertServiceClient(coreConn),
+		awsClient:            aws.NewAWSServiceClient(datasourceConn),
+		osintClient:          osint.NewOsintServiceClient(datasourceConn),
+		diagnosisClient:      diagnosis.NewDiagnosisServiceClient(datasourceConn),
+		codeClient:           code.NewCodeServiceClient(datasourceConn),
+		googleClient:         google.NewGoogleServiceClient(datasourceConn),
+		azureClient:          azure.NewAzureServiceClient(datasourceConn),
+		aiClient:             ai.NewAIServiceClient(coreConn),
+		claimsClient:         newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
+		datasourceClient:     datasource.NewDataSourceServiceClient(datasourceConn),
 	}, nil
 }
 

--- a/service.go
+++ b/service.go
@@ -131,7 +131,7 @@ func validateGatewayConfig(conf *AppConfig) error {
 	if conf.GithubAppOAuthRedirectURL == "" {
 		return errors.New("github app oauth redirect url is required when github app oauth client id is configured")
 	}
-	if _, err := validateGitHubAppOAuthRedirectURL(conf.GithubAppOAuthRedirectURL); err != nil {
+	if _, err := validateGitHubAppOAuthRedirectURL(conf.GithubAppOAuthRedirectURL, isLocalEnv(conf.EnvName)); err != nil {
 		return err
 	}
 	if conf.GithubAppStateSecret == "" {

--- a/service.go
+++ b/service.go
@@ -116,6 +116,9 @@ func validateGatewayConfig(conf *AppConfig) error {
 	if conf.GithubAppInstallURL == "" {
 		return nil
 	}
+	if _, err := parseGitHubAppInstallURL(conf.GithubAppInstallURL); err != nil {
+		return err
+	}
 	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
 		return errors.New("github app state secret must be at least 32 bytes when github app install url is configured")
 	}

--- a/service.go
+++ b/service.go
@@ -113,17 +113,20 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 }
 
 func validateGatewayConfig(conf *AppConfig) error {
-	if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-		return errors.New("github app state secret must be at least 32 bytes")
-	}
 	if conf.GithubAppInstallURL == "" {
+		if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
+			return errors.New("github app state secret must be empty or at least 32 bytes when github app install url is not configured")
+		}
 		return nil
 	}
 	if _, err := parseGitHubAppInstallURL(conf.GithubAppInstallURL); err != nil {
 		return err
 	}
+	if conf.GithubAppStateSecret == "" {
+		return errors.New("github app state secret is required when github app install url is configured")
+	}
 	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
-		return errors.New("github app state secret must be at least 32 bytes")
+		return errors.New("github app state secret must be at least 32 bytes when github app install url is configured")
 	}
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/ca-risken/common/pkg/logging"
@@ -47,8 +46,6 @@ type gatewayService struct {
 	sessionTimeoutSec    int
 	githubAppSlug        string
 	githubAppStateSecret string
-	githubAppStateMu     sync.Mutex
-	githubAppUsedStates  map[string]int64
 	findingClient        finding.FindingServiceClient
 	iamClient            iam.IAMServiceClient
 	projectClient        project.ProjectServiceClient

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -27,7 +26,6 @@ type githubAppOAuthState struct {
 	GithubSettingID uint32 `json:"github_setting_id"`
 	UserID          uint32 `json:"user_id"`
 	ReturnTo        string `json:"return_to"`
-	Random          string `json:"random"`
 	ExpiresAt       int64  `json:"expires_at"`
 }
 
@@ -141,16 +139,11 @@ func validateGitHubAppReturnTo(returnTo string) error {
 }
 
 func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
-	randomBytes := make([]byte, 16)
-	if _, err := rand.Read(randomBytes); err != nil {
-		return "", err
-	}
 	state := &githubAppOAuthState{
 		ProjectID:       projectID,
 		GithubSettingID: githubSettingID,
 		UserID:          userID,
 		ReturnTo:        returnTo,
-		Random:          base64.RawURLEncoding.EncodeToString(randomBytes),
 		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
 	}
 	return g.signGitHubAppOAuthState(state)
@@ -189,7 +182,7 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if err := json.Unmarshal(payload, state); err != nil {
 		return nil, err
 	}
-	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" || state.Random == "" {
+	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" {
 		return nil, errors.New("invalid state payload")
 	}
 	if now.Unix() > state.ExpiresAt {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ca-risken/datasource-api/proto/code"
+)
+
+const (
+	githubAppOAuthCallbackPath = "/api/v1/code/github-app/oauth/callback"
+	githubAppStateTTL          = 10 * time.Minute
+)
+
+type githubAppOAuthState struct {
+	ProjectID       uint32 `json:"project_id"`
+	GithubSettingID uint32 `json:"github_setting_id"`
+	UserID          uint32 `json:"user_id"`
+	ReturnTo        string `json:"return_to"`
+	Nonce           string `json:"nonce"`
+	ExpiresAt       int64  `json:"expires_at"`
+}
+
+func (g *gatewayService) githubAppInstallURLHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	u, err := getRequestUser(r)
+	if err != nil || !isHumanAccess(u) {
+		writeResponse(ctx, w, http.StatusUnauthorized, map[string]any{errorJSONKey: "Unauthenticated"})
+		return
+	}
+	projectID, err := parseRequiredUint32(r, "project_id")
+	if err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	githubSettingID, err := parseRequiredUint32(r, "github_setting_id")
+	if err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	returnTo, err := normalizeGitHubAppReturnTo(r.URL.Query().Get("return_to"), projectID)
+	if err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	state, err := g.newGitHubAppOAuthState(projectID, githubSettingID, u.userID, returnTo, time.Now())
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to create github app oauth state: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth is not configured"})
+		return
+	}
+	installURL, err := g.buildGitHubAppInstallURL(state)
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to build github app install url: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App install URL is not configured"})
+		return
+	}
+	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": installURL}})
+}
+
+func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	u, err := getRequestUser(r)
+	if err != nil || !isHumanAccess(u) {
+		writeResponse(ctx, w, http.StatusUnauthorized, map[string]any{errorJSONKey: "Unauthenticated"})
+		return
+	}
+	state, err := g.verifyGitHubAppOAuthState(r.URL.Query().Get("state"), time.Now())
+	if err != nil {
+		appLogger.Warnf(ctx, "Invalid github app oauth state: err=%+v", err)
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: "Invalid GitHub App OAuth state"})
+		return
+	}
+	if state.UserID != u.userID {
+		appLogger.Warnf(ctx, "GitHub App OAuth state user mismatch: state_user_id=%d, request_user_id=%d", state.UserID, u.userID)
+		writeResponse(ctx, w, http.StatusForbidden, map[string]any{errorJSONKey: "Invalid GitHub App OAuth state"})
+		return
+	}
+	if !g.isAuthorizedProject(ctx, u.userID, state.ProjectID, r.URL.Path) {
+		writeResponse(ctx, w, http.StatusForbidden, map[string]any{errorJSONKey: "Unauthorized the project resource for human access"})
+		return
+	}
+	oauthCode := r.URL.Query().Get("code")
+	if strings.TrimSpace(oauthCode) == "" {
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "failed")
+		return
+	}
+	if _, err := g.codeClient.VerifyGitHubAppUser(ctx, &code.VerifyGitHubAppUserRequest{
+		ProjectId:       state.ProjectID,
+		GithubSettingId: state.GithubSettingID,
+		Code:            oauthCode,
+	}); err != nil {
+		appLogger.Warnf(ctx, "Failed to verify github app oauth user: project_id=%d, github_setting_id=%d, err=%+v", state.ProjectID, state.GithubSettingID, err)
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "failed")
+		return
+	}
+	g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "success")
+}
+
+func parseRequiredUint32(r *http.Request, name string) (uint32, error) {
+	value := r.URL.Query().Get(name)
+	if value == "" {
+		return 0, fmt.Errorf("required %s", name)
+	}
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil || parsed == 0 {
+		return 0, fmt.Errorf("invalid %s", name)
+	}
+	return uint32(parsed), nil
+}
+
+func normalizeGitHubAppReturnTo(returnTo string, projectID uint32) (string, error) {
+	if returnTo == "" {
+		return fmt.Sprintf("/code/github?project_id=%d", projectID), nil
+	}
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		return "", err
+	}
+	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(returnTo, "/") || strings.HasPrefix(returnTo, "//") {
+		return "", errors.New("return_to must be a relative path")
+	}
+	return returnTo, nil
+}
+
+func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return "", err
+	}
+	state := &githubAppOAuthState{
+		ProjectID:       projectID,
+		GithubSettingID: githubSettingID,
+		UserID:          userID,
+		ReturnTo:        returnTo,
+		Nonce:           base64.RawURLEncoding.EncodeToString(nonceBytes),
+		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
+	}
+	return g.signGitHubAppOAuthState(state)
+}
+
+func (g *gatewayService) signGitHubAppOAuthState(state *githubAppOAuthState) (string, error) {
+	if g.githubAppStateSecret == "" {
+		return "", errors.New("github app state secret is required")
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signature := signGitHubAppState(encodedPayload, g.githubAppStateSecret)
+	return encodedPayload + "." + signature, nil
+}
+
+func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Time) (*githubAppOAuthState, error) {
+	if g.githubAppStateSecret == "" {
+		return nil, errors.New("github app state secret is required")
+	}
+	parts := strings.Split(rawState, ".")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid state format")
+	}
+	expectedSignature := signGitHubAppState(parts[0], g.githubAppStateSecret)
+	if !hmac.Equal([]byte(expectedSignature), []byte(parts[1])) {
+		return nil, errors.New("invalid state signature")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	state := &githubAppOAuthState{}
+	if err := json.Unmarshal(payload, state); err != nil {
+		return nil, err
+	}
+	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" || state.Nonce == "" {
+		return nil, errors.New("invalid state payload")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return nil, errors.New("expired state")
+	}
+	return state, nil
+}
+
+func signGitHubAppState(payload, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (g *gatewayService) buildGitHubAppInstallURL(state string) (string, error) {
+	if g.githubAppInstallURL == "" {
+		return "", errors.New("github app install url is required")
+	}
+	u, err := url.Parse(g.githubAppInstallURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return "", errors.New("github app install url must be https")
+	}
+	q := u.Query()
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		http.Redirect(w, r, "/code/github?github_app_oauth=failed", http.StatusFound)
+		return
+	}
+	q := u.Query()
+	q.Set("github_app_oauth", result)
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -27,7 +26,6 @@ type githubAppOAuthState struct {
 	GithubSettingID uint32 `json:"github_setting_id"`
 	UserID          uint32 `json:"user_id"`
 	ReturnTo        string `json:"return_to"`
-	Nonce           string `json:"nonce"`
 	ExpiresAt       int64  `json:"expires_at"`
 }
 
@@ -134,16 +132,11 @@ func normalizeGitHubAppReturnTo(returnTo string, projectID uint32) (string, erro
 }
 
 func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
-	nonceBytes := make([]byte, 16)
-	if _, err := rand.Read(nonceBytes); err != nil {
-		return "", err
-	}
 	state := &githubAppOAuthState{
 		ProjectID:       projectID,
 		GithubSettingID: githubSettingID,
 		UserID:          userID,
 		ReturnTo:        returnTo,
-		Nonce:           base64.RawURLEncoding.EncodeToString(nonceBytes),
 		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
 	}
 	return g.signGitHubAppOAuthState(state)
@@ -182,7 +175,7 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if err := json.Unmarshal(payload, state); err != nil {
 		return nil, err
 	}
-	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" || state.Nonce == "" {
+	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" {
 		return nil, errors.New("invalid state payload")
 	}
 	if now.Unix() > state.ExpiresAt {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -20,7 +21,10 @@ import (
 const (
 	githubAppOAuthCallbackPath = "/api/v1/code/github-app/oauth/callback"
 	githubAppStateTTL          = 10 * time.Minute
+	githubAppInstallURLFormat  = "https://github.com/apps/%s/installations/select_target"
 )
+
+var githubAppSlugPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
 
 type githubAppOAuthState struct {
 	ProjectID       uint32 `json:"project_id"`
@@ -59,10 +63,10 @@ func (g *gatewayService) githubAppOAuthStartHandler(w http.ResponseWriter, r *ht
 		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth is not configured"})
 		return
 	}
-	installURL, err := g.buildGitHubAppInstallURL(state)
+	installURL, err := g.buildGitHubAppOAuthStartURL(state)
 	if err != nil {
-		appLogger.Errorf(ctx, "Failed to build github app install url: err=%+v", err)
-		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App install URL is not configured"})
+		appLogger.Errorf(ctx, "Failed to build github app oauth start url: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth start URL is not configured"})
 		return
 	}
 	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": installURL}})
@@ -207,11 +211,11 @@ func signGitHubAppState(payload, secret string) string {
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 }
 
-func (g *gatewayService) buildGitHubAppInstallURL(state string) (string, error) {
-	if g.githubAppInstallURL == "" {
-		return "", errors.New("github app install url is required")
+func (g *gatewayService) buildGitHubAppOAuthStartURL(state string) (string, error) {
+	if err := validateGitHubAppSlug(g.githubAppSlug); err != nil {
+		return "", err
 	}
-	u, err := parseGitHubAppInstallURL(g.githubAppInstallURL)
+	u, err := url.Parse(fmt.Sprintf(githubAppInstallURLFormat, g.githubAppSlug))
 	if err != nil {
 		return "", err
 	}
@@ -221,15 +225,11 @@ func (g *gatewayService) buildGitHubAppInstallURL(state string) (string, error) 
 	return u.String(), nil
 }
 
-func parseGitHubAppInstallURL(rawURL string) (*url.URL, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
+func validateGitHubAppSlug(slug string) error {
+	if !githubAppSlugPattern.MatchString(slug) {
+		return errors.New("github app slug is invalid")
 	}
-	if u.Scheme != "https" || u.Host == "" {
-		return nil, errors.New("github app install url must be https")
-	}
-	return u, nil
+	return nil
 }
 
 func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -78,7 +78,7 @@ func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r 
 	}
 	u, err := getRequestUser(r)
 	if err != nil || !isHumanAccess(u) {
-		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "failed")
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "session_expired")
 		return
 	}
 	if state.UserID != u.userID {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -31,7 +31,7 @@ type githubAppOAuthState struct {
 	ExpiresAt       int64  `json:"expires_at"`
 }
 
-func (g *gatewayService) githubAppInstallURLHandler(w http.ResponseWriter, r *http.Request) {
+func (g *gatewayService) githubAppOAuthStartHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	u, err := getRequestUser(r)
 	if err != nil || !isHumanAccess(u) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -121,14 +121,21 @@ func normalizeGitHubAppReturnTo(returnTo string, projectID uint32) (string, erro
 	if returnTo == "" {
 		return fmt.Sprintf("/code/github?project_id=%d", projectID), nil
 	}
-	u, err := url.Parse(returnTo)
-	if err != nil {
+	if err := validateGitHubAppReturnTo(returnTo); err != nil {
 		return "", err
 	}
-	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(returnTo, "/") || strings.HasPrefix(returnTo, "//") || strings.ContainsRune(returnTo, '\\') {
-		return "", errors.New("return_to must be a relative path")
-	}
 	return returnTo, nil
+}
+
+func validateGitHubAppReturnTo(returnTo string) error {
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		return err
+	}
+	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(returnTo, "/") || strings.HasPrefix(returnTo, "//") || strings.ContainsRune(returnTo, '\\') {
+		return errors.New("return_to must be a relative path")
+	}
+	return nil
 }
 
 func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
@@ -194,12 +201,9 @@ func (g *gatewayService) buildGitHubAppInstallURL(state string) (string, error) 
 	if g.githubAppInstallURL == "" {
 		return "", errors.New("github app install url is required")
 	}
-	u, err := url.Parse(g.githubAppInstallURL)
+	u, err := parseGitHubAppInstallURL(g.githubAppInstallURL)
 	if err != nil {
 		return "", err
-	}
-	if u.Scheme != "https" || u.Host == "" {
-		return "", errors.New("github app install url must be https")
 	}
 	q := u.Query()
 	q.Set("state", state)
@@ -207,7 +211,22 @@ func (g *gatewayService) buildGitHubAppInstallURL(state string) (string, error) 
 	return u.String(), nil
 }
 
+func parseGitHubAppInstallURL(rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return nil, errors.New("github app install url must be https")
+	}
+	return u, nil
+}
+
 func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {
+	if err := validateGitHubAppReturnTo(returnTo); err != nil {
+		http.Redirect(w, r, "/code/github?github_app_oauth=failed", http.StatusFound)
+		return
+	}
 	u, err := url.Parse(returnTo)
 	if err != nil {
 		http.Redirect(w, r, "/code/github?github_app_oauth=failed", http.StatusFound)

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -83,11 +83,11 @@ func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r 
 	}
 	if state.UserID != u.userID {
 		appLogger.Warnf(ctx, "GitHub App OAuth state user mismatch: state_user_id=%d, request_user_id=%d", state.UserID, u.userID)
-		writeResponse(ctx, w, http.StatusForbidden, map[string]any{errorJSONKey: "Invalid GitHub App OAuth state"})
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "unauthorized")
 		return
 	}
 	if !g.isAuthorizedProject(ctx, u.userID, state.ProjectID, r.URL.Path) {
-		writeResponse(ctx, w, http.StatusForbidden, map[string]any{errorJSONKey: "Unauthorized the project resource for human access"})
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "unauthorized")
 		return
 	}
 	oauthCode := r.URL.Query().Get("code")

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -26,6 +27,7 @@ type githubAppOAuthState struct {
 	GithubSettingID uint32 `json:"github_setting_id"`
 	UserID          uint32 `json:"user_id"`
 	ReturnTo        string `json:"return_to"`
+	Random          string `json:"random"`
 	ExpiresAt       int64  `json:"expires_at"`
 }
 
@@ -139,11 +141,16 @@ func validateGitHubAppReturnTo(returnTo string) error {
 }
 
 func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
+	randomBytes := make([]byte, 16)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
 	state := &githubAppOAuthState{
 		ProjectID:       projectID,
 		GithubSettingID: githubSettingID,
 		UserID:          userID,
 		ReturnTo:        returnTo,
+		Random:          base64.RawURLEncoding.EncodeToString(randomBytes),
 		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
 	}
 	return g.signGitHubAppOAuthState(state)
@@ -182,7 +189,7 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if err := json.Unmarshal(payload, state); err != nil {
 		return nil, err
 	}
-	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" {
+	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" || state.Random == "" {
 		return nil, errors.New("invalid state payload")
 	}
 	if err := validateGitHubAppReturnTo(state.ReturnTo); err != nil {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -26,6 +27,7 @@ type githubAppOAuthState struct {
 	GithubSettingID uint32 `json:"github_setting_id"`
 	UserID          uint32 `json:"user_id"`
 	ReturnTo        string `json:"return_to"`
+	Random          string `json:"random"`
 	ExpiresAt       int64  `json:"expires_at"`
 }
 
@@ -139,11 +141,16 @@ func validateGitHubAppReturnTo(returnTo string) error {
 }
 
 func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
+	randomBytes := make([]byte, 16)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
 	state := &githubAppOAuthState{
 		ProjectID:       projectID,
 		GithubSettingID: githubSettingID,
 		UserID:          userID,
 		ReturnTo:        returnTo,
+		Random:          base64.RawURLEncoding.EncodeToString(randomBytes),
 		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
 	}
 	return g.signGitHubAppOAuthState(state)
@@ -182,7 +189,7 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if err := json.Unmarshal(payload, state); err != nil {
 		return nil, err
 	}
-	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" {
+	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" || state.Random == "" {
 		return nil, errors.New("invalid state payload")
 	}
 	if now.Unix() > state.ExpiresAt {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -125,7 +125,7 @@ func normalizeGitHubAppReturnTo(returnTo string, projectID uint32) (string, erro
 	if err != nil {
 		return "", err
 	}
-	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(returnTo, "/") || strings.HasPrefix(returnTo, "//") {
+	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(returnTo, "/") || strings.HasPrefix(returnTo, "//") || strings.ContainsRune(returnTo, '\\') {
 		return "", errors.New("return_to must be a relative path")
 	}
 	return returnTo, nil

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -232,12 +232,17 @@ func (g *gatewayService) buildGitHubAppOAuthStartURL(state string) (string, erro
 	if clientID == "" {
 		return "", errors.New("github app oauth client id is required")
 	}
+	redirectURL, err := validateGitHubAppOAuthRedirectURL(g.githubAppRedirectURL)
+	if err != nil {
+		return "", err
+	}
 	u, err := url.Parse(githubAppOAuthAuthorizeURL)
 	if err != nil {
 		return "", err
 	}
 	q := u.Query()
 	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURL)
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
@@ -256,6 +261,21 @@ func validateGitHubAppSlug(slug string) error {
 		return errors.New("github app slug is invalid")
 	}
 	return nil
+}
+
+func validateGitHubAppOAuthRedirectURL(redirectURL string) (string, error) {
+	redirectURL = strings.TrimSpace(redirectURL)
+	if redirectURL == "" {
+		return "", errors.New("github app oauth redirect url is required")
+	}
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		return "", err
+	}
+	if (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		return "", errors.New("github app oauth redirect url must be an absolute http or https URL")
+	}
+	return redirectURL, nil
 }
 
 func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -21,10 +20,8 @@ import (
 const (
 	githubAppOAuthCallbackPath = "/api/v1/code/github-app/oauth/callback"
 	githubAppStateTTL          = 10 * time.Minute
-	githubAppInstallURLFormat  = "https://github.com/apps/%s/installations/select_target"
+	githubAppOAuthAuthorizeURL = "https://github.com/login/oauth/authorize"
 )
-
-var githubAppSlugPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
 
 type githubAppOAuthState struct {
 	ProjectID       uint32 `json:"project_id"`
@@ -63,13 +60,13 @@ func (g *gatewayService) githubAppOAuthStartHandler(w http.ResponseWriter, r *ht
 		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth is not configured"})
 		return
 	}
-	installURL, err := g.buildGitHubAppOAuthStartURL(state)
+	oauthURL, err := g.buildGitHubAppOAuthStartURL(state)
 	if err != nil {
 		appLogger.Errorf(ctx, "Failed to build github app oauth start url: err=%+v", err)
 		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth start URL is not configured"})
 		return
 	}
-	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": installURL}})
+	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": oauthURL}})
 }
 
 func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r *http.Request) {
@@ -212,24 +209,19 @@ func signGitHubAppState(payload, secret string) string {
 }
 
 func (g *gatewayService) buildGitHubAppOAuthStartURL(state string) (string, error) {
-	if err := validateGitHubAppSlug(g.githubAppSlug); err != nil {
-		return "", err
+	clientID := strings.TrimSpace(g.githubAppClientID)
+	if clientID == "" {
+		return "", errors.New("github app oauth client id is required")
 	}
-	u, err := url.Parse(fmt.Sprintf(githubAppInstallURLFormat, g.githubAppSlug))
+	u, err := url.Parse(githubAppOAuthAuthorizeURL)
 	if err != nil {
 		return "", err
 	}
 	q := u.Query()
+	q.Set("client_id", clientID)
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
-}
-
-func validateGitHubAppSlug(slug string) error {
-	if !githubAppSlugPattern.MatchString(slug) {
-		return errors.New("github app slug is invalid")
-	}
-	return nil
 }
 
 func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -68,15 +68,15 @@ func (g *gatewayService) githubAppInstallURLHandler(w http.ResponseWriter, r *ht
 
 func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	u, err := getRequestUser(r)
-	if err != nil || !isHumanAccess(u) {
-		writeResponse(ctx, w, http.StatusUnauthorized, map[string]any{errorJSONKey: "Unauthenticated"})
-		return
-	}
 	state, err := g.verifyGitHubAppOAuthState(r.URL.Query().Get("state"), time.Now())
 	if err != nil {
 		appLogger.Warnf(ctx, "Invalid github app oauth state: err=%+v", err)
 		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: "Invalid GitHub App OAuth state"})
+		return
+	}
+	u, err := getRequestUser(r)
+	if err != nil || !isHumanAccess(u) {
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "failed")
 		return
 	}
 	if state.UserID != u.userID {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -185,6 +185,9 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" {
 		return nil, errors.New("invalid state payload")
 	}
+	if err := validateGitHubAppReturnTo(state.ReturnTo); err != nil {
+		return nil, err
+	}
 	if now.Unix() > state.ExpiresAt {
 		return nil, errors.New("expired state")
 	}

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -202,7 +202,29 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if now.Unix() > state.ExpiresAt {
 		return nil, errors.New("expired state")
 	}
+	if err := g.consumeGitHubAppOAuthState(rawState, state.ExpiresAt, now); err != nil {
+		return nil, err
+	}
 	return state, nil
+}
+
+func (g *gatewayService) consumeGitHubAppOAuthState(rawState string, expiresAt int64, now time.Time) error {
+	g.githubAppStateMu.Lock()
+	defer g.githubAppStateMu.Unlock()
+	if g.githubAppUsedStates == nil {
+		g.githubAppUsedStates = map[string]int64{}
+	}
+	nowUnix := now.Unix()
+	for usedState, usedExpiresAt := range g.githubAppUsedStates {
+		if nowUnix > usedExpiresAt {
+			delete(g.githubAppUsedStates, usedState)
+		}
+	}
+	if _, ok := g.githubAppUsedStates[rawState]; ok {
+		return errors.New("state has already been used")
+	}
+	g.githubAppUsedStates[rawState] = expiresAt
+	return nil
 }
 
 func signGitHubAppState(payload, secret string) string {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -232,7 +232,7 @@ func (g *gatewayService) buildGitHubAppOAuthStartURL(state string) (string, erro
 	if clientID == "" {
 		return "", errors.New("github app oauth client id is required")
 	}
-	redirectURL, err := validateGitHubAppOAuthRedirectURL(g.githubAppRedirectURL)
+	redirectURL, err := validateGitHubAppOAuthRedirectURL(g.githubAppRedirectURL, isLocalEnv(g.envName))
 	if err != nil {
 		return "", err
 	}
@@ -263,7 +263,7 @@ func validateGitHubAppSlug(slug string) error {
 	return nil
 }
 
-func validateGitHubAppOAuthRedirectURL(redirectURL string) (string, error) {
+func validateGitHubAppOAuthRedirectURL(redirectURL string, allowLocalHTTP bool) (string, error) {
 	redirectURL = strings.TrimSpace(redirectURL)
 	if redirectURL == "" {
 		return "", errors.New("github app oauth redirect url is required")
@@ -272,10 +272,25 @@ func validateGitHubAppOAuthRedirectURL(redirectURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
-		return "", errors.New("github app oauth redirect url must be an absolute http or https URL")
+	if u.Host == "" {
+		return "", errors.New("github app oauth redirect url must be an absolute URL")
 	}
-	return redirectURL, nil
+	if u.Scheme == "https" {
+		return redirectURL, nil
+	}
+	if u.Scheme == "http" && allowLocalHTTP && isLocalHost(u.Hostname()) {
+		return redirectURL, nil
+	}
+	return "", errors.New("github app oauth redirect url must use https except local localhost")
+}
+
+func isLocalEnv(envName string) bool {
+	return strings.EqualFold(strings.TrimSpace(envName), "local")
+}
+
+func isLocalHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -202,29 +202,7 @@ func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Tim
 	if now.Unix() > state.ExpiresAt {
 		return nil, errors.New("expired state")
 	}
-	if err := g.consumeGitHubAppOAuthState(rawState, state.ExpiresAt, now); err != nil {
-		return nil, err
-	}
 	return state, nil
-}
-
-func (g *gatewayService) consumeGitHubAppOAuthState(rawState string, expiresAt int64, now time.Time) error {
-	g.githubAppStateMu.Lock()
-	defer g.githubAppStateMu.Unlock()
-	if g.githubAppUsedStates == nil {
-		g.githubAppUsedStates = map[string]int64{}
-	}
-	nowUnix := now.Unix()
-	for usedState, usedExpiresAt := range g.githubAppUsedStates {
-		if nowUnix > usedExpiresAt {
-			delete(g.githubAppUsedStates, usedState)
-		}
-	}
-	if _, ok := g.githubAppUsedStates[rawState]; ok {
-		return errors.New("state has already been used")
-	}
-	g.githubAppUsedStates[rawState] = expiresAt
-	return nil
 }
 
 func signGitHubAppState(payload, secret string) string {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -21,7 +22,10 @@ const (
 	githubAppOAuthCallbackPath = "/api/v1/code/github-app/oauth/callback"
 	githubAppStateTTL          = 10 * time.Minute
 	githubAppOAuthAuthorizeURL = "https://github.com/login/oauth/authorize"
+	githubAppInstallURLFormat  = "https://github.com/apps/%s/installations/select_target"
 )
+
+var githubAppSlugPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
 
 type githubAppOAuthState struct {
 	ProjectID       uint32 `json:"project_id"`
@@ -30,6 +34,21 @@ type githubAppOAuthState struct {
 	ReturnTo        string `json:"return_to"`
 	Random          string `json:"random"`
 	ExpiresAt       int64  `json:"expires_at"`
+}
+
+func (g *gatewayService) githubAppInstallURLHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if _, err := parseRequiredUint32(r, "project_id"); err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	installURL, err := g.buildGitHubAppInstallURL()
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to build github app install url: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App install URL is not configured"})
+		return
+	}
+	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": installURL}})
 }
 
 func (g *gatewayService) githubAppOAuthStartHandler(w http.ResponseWriter, r *http.Request) {
@@ -222,6 +241,21 @@ func (g *gatewayService) buildGitHubAppOAuthStartURL(state string) (string, erro
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+func (g *gatewayService) buildGitHubAppInstallURL() (string, error) {
+	slug := strings.TrimSpace(g.githubAppSlug)
+	if err := validateGitHubAppSlug(slug); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(githubAppInstallURLFormat, slug), nil
+}
+
+func validateGitHubAppSlug(slug string) error {
+	if !githubAppSlugPattern.MatchString(slug) {
+		return errors.New("github app slug is invalid")
+	}
+	return nil
 }
 
 func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -26,23 +26,6 @@ func TestGitHubAppOAuthState(t *testing.T) {
 	}
 }
 
-func TestNewGitHubAppOAuthStateGeneratesUniqueToken(t *testing.T) {
-	svc := &gatewayService{githubAppStateSecret: "state-secret"}
-	now := time.Unix(1700000000, 0)
-
-	state1, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	state2, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if state1 == state2 {
-		t.Fatal("Expected unique state tokens")
-	}
-}
-
 func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: "state-secret"}
 	now := time.Unix(1700000000, 0)

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -28,6 +28,23 @@ func TestGitHubAppOAuthState(t *testing.T) {
 	}
 }
 
+func TestNewGitHubAppOAuthStateGeneratesUniqueToken(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	now := time.Unix(1700000000, 0)
+
+	state1, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	state2, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if state1 == state2 {
+		t.Fatal("Expected unique state tokens")
+	}
+}
+
 func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
 	now := time.Unix(1700000000, 0)
@@ -40,6 +57,7 @@ func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 		GithubSettingID: 10,
 		UserID:          20,
 		ReturnTo:        `/\attacker.example/path`,
+		Random:          "test-random",
 		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
 	})
 	if err != nil {

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -1,15 +1,33 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ca-risken/core/proto/iam"
+	iammocks "github.com/ca-risken/core/proto/iam/mocks"
+	"github.com/stretchr/testify/mock"
 )
 
 const testGitHubAppStateSecret = "12345678901234567890123456789012"
+
+func newGitHubAppOAuthCallbackRequest(t *testing.T, svc *gatewayService, userID uint32) *http.Request {
+	t.Helper()
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", time.Now())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/oauth/callback?state="+url.QueryEscape(rawState)+"&code=oauth-code", nil)
+	if userID != 0 {
+		req = req.WithContext(context.WithValue(req.Context(), userKey, &requestUser{userID: userID}))
+	}
+	return req
+}
 
 func TestGitHubAppOAuthState(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
@@ -168,11 +186,7 @@ func TestRedirectGitHubAppOAuthResultRejectsInvalidReturnTo(t *testing.T) {
 
 func TestGitHubAppOAuthCallbackHandlerRedirectsWhenSessionExpired(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
-	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", time.Now())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/oauth/callback?state="+url.QueryEscape(rawState)+"&code=oauth-code", nil)
+	req := newGitHubAppOAuthCallbackRequest(t, svc, 0)
 	rec := httptest.NewRecorder()
 
 	svc.githubAppOAuthCallbackHandler(rec, req)
@@ -181,6 +195,41 @@ func TestGitHubAppOAuthCallbackHandlerRedirectsWhenSessionExpired(t *testing.T) 
 		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
 	}
 	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=session_expired&project_id=1001" {
+		t.Fatalf("Unexpected Location: %s", got)
+	}
+}
+
+func TestGitHubAppOAuthCallbackHandlerRedirectsWhenUserMismatch(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	req := newGitHubAppOAuthCallbackRequest(t, svc, 21)
+	rec := httptest.NewRecorder()
+
+	svc.githubAppOAuthCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=unauthorized&project_id=1001" {
+		t.Fatalf("Unexpected Location: %s", got)
+	}
+}
+
+func TestGitHubAppOAuthCallbackHandlerRedirectsWhenProjectUnauthorized(t *testing.T) {
+	iamMock := iammocks.NewIAMServiceClient(t)
+	iamMock.On("IsAuthorized", mock.Anything, mock.Anything).Return(&iam.IsAuthorizedResponse{Ok: false}, nil).Once()
+	svc := &gatewayService{
+		githubAppStateSecret: testGitHubAppStateSecret,
+		iamClient:            iamMock,
+	}
+	req := newGitHubAppOAuthCallbackRequest(t, svc, 20)
+	rec := httptest.NewRecorder()
+
+	svc.githubAppOAuthCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=unauthorized&project_id=1001" {
 		t.Fatalf("Unexpected Location: %s", got)
 	}
 }

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGitHubAppOAuthState(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: "state-secret"}
+	now := time.Unix(1700000000, 0)
+
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	state, err := svc.verifyGitHubAppOAuthState(rawState, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("Unexpected verify error: %v", err)
+	}
+	if state.ProjectID != 1001 || state.GithubSettingID != 10 || state.UserID != 20 || state.ReturnTo != "/code/github?project_id=1001" {
+		t.Fatalf("Unexpected state: %+v", state)
+	}
+}
+
+func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: "state-secret"}
+	now := time.Unix(1700000000, 0)
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		state string
+		now   time.Time
+	}{
+		{name: "invalid format", state: "invalid", now: now},
+		{name: "invalid signature", state: rawState + "x", now: now},
+		{name: "expired", state: rawState, now: now.Add(githubAppStateTTL + time.Second)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := svc.verifyGitHubAppOAuthState(c.state, c.now); err == nil {
+				t.Fatal("Expected error but got none")
+			}
+		})
+	}
+}
+
+func TestBuildGitHubAppInstallURL(t *testing.T) {
+	svc := &gatewayService{githubAppInstallURL: "https://github.com/apps/risken-codescan/installations/new?existing=1"}
+	got, err := svc.buildGitHubAppInstallURL("state-value")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "https://github.com/apps/risken-codescan/installations/new?existing=1&state=state-value" {
+		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
+func TestNormalizeGitHubAppReturnTo(t *testing.T) {
+	got, err := normalizeGitHubAppReturnTo("", 1001)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "/code/github?project_id=1001" {
+		t.Fatalf("Unexpected return_to: %s", got)
+	}
+
+	if _, err := normalizeGitHubAppReturnTo("https://attacker.example", 1001); err == nil {
+		t.Fatal("Expected absolute URL error but got none")
+	}
+	if _, err := normalizeGitHubAppReturnTo("//attacker.example/path", 1001); err == nil {
+		t.Fatal("Expected protocol-relative URL error but got none")
+	}
+	if _, err := normalizeGitHubAppReturnTo("code/github", 1001); err == nil {
+		t.Fatal("Expected non-relative path error but got none")
+	}
+}
+
+func TestBuildGitHubAppInstallURLRejectsInvalidConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		installURL string
+	}{
+		{name: "empty"},
+		{name: "http", installURL: "http://github.com/apps/risken/installations/new"},
+		{name: "relative", installURL: "/apps/risken/installations/new"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{githubAppInstallURL: c.installURL}
+			_, err := svc.buildGitHubAppInstallURL("state")
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 )
 
+const testGitHubAppStateSecret = "12345678901234567890123456789012"
+
 func TestGitHubAppOAuthState(t *testing.T) {
-	svc := &gatewayService{githubAppStateSecret: "state-secret"}
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
 	now := time.Unix(1700000000, 0)
 
 	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
@@ -27,9 +29,19 @@ func TestGitHubAppOAuthState(t *testing.T) {
 }
 
 func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
-	svc := &gatewayService{githubAppStateSecret: "state-secret"}
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
 	now := time.Unix(1700000000, 0)
 	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	invalidReturnToState, err := svc.signGitHubAppOAuthState(&githubAppOAuthState{
+		ProjectID:       1001,
+		GithubSettingID: 10,
+		UserID:          20,
+		ReturnTo:        `/\attacker.example/path`,
+		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -41,6 +53,7 @@ func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	}{
 		{name: "invalid format", state: "invalid", now: now},
 		{name: "invalid signature", state: rawState + "x", now: now},
+		{name: "invalid return_to", state: invalidReturnToState, now: now},
 		{name: "expired", state: rawState, now: now.Add(githubAppStateTTL + time.Second)},
 	}
 	for _, c := range cases {
@@ -136,7 +149,7 @@ func TestRedirectGitHubAppOAuthResultRejectsInvalidReturnTo(t *testing.T) {
 }
 
 func TestGitHubAppOAuthCallbackHandlerRedirectsWhenSessionExpired(t *testing.T) {
-	svc := &gatewayService{githubAppStateSecret: "12345678901234567890123456789012"}
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
 	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", time.Now())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -63,6 +63,22 @@ func TestNewGitHubAppOAuthStateGeneratesUniqueToken(t *testing.T) {
 	}
 }
 
+func TestVerifyGitHubAppOAuthStateRejectsReplay(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	now := time.Unix(1700000000, 0)
+
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if _, err := svc.verifyGitHubAppOAuthState(rawState, now.Add(time.Minute)); err != nil {
+		t.Fatalf("Unexpected verify error: %v", err)
+	}
+	if _, err := svc.verifyGitHubAppOAuthState(rawState, now.Add(2*time.Minute)); err == nil {
+		t.Fatal("Expected replay error but got none")
+	}
+}
+
 func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
 	now := time.Unix(1700000000, 0)

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -101,13 +101,13 @@ func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	}
 }
 
-func TestBuildGitHubAppInstallURL(t *testing.T) {
-	svc := &gatewayService{githubAppInstallURL: "https://github.com/apps/risken-codescan/installations/new?existing=1"}
-	got, err := svc.buildGitHubAppInstallURL("state-value")
+func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
+	svc := &gatewayService{githubAppSlug: "risken-codescan"}
+	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if got != "https://github.com/apps/risken-codescan/installations/new?existing=1&state=state-value" {
+	if got != "https://github.com/apps/risken-codescan/installations/select_target?state=state-value" {
 		t.Fatalf("Unexpected URL: %s", got)
 	}
 }
@@ -135,19 +135,19 @@ func TestNormalizeGitHubAppReturnTo(t *testing.T) {
 	}
 }
 
-func TestBuildGitHubAppInstallURLRejectsInvalidConfig(t *testing.T) {
+func TestBuildGitHubAppOAuthStartURLRejectsInvalidSlug(t *testing.T) {
 	cases := []struct {
-		name       string
-		installURL string
+		name string
+		slug string
 	}{
 		{name: "empty"},
-		{name: "http", installURL: "http://github.com/apps/risken/installations/new"},
-		{name: "relative", installURL: "/apps/risken/installations/new"},
+		{name: "slash", slug: "owner/risken"},
+		{name: "leading hyphen", slug: "-risken"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			svc := &gatewayService{githubAppInstallURL: c.installURL}
-			_, err := svc.buildGitHubAppInstallURL("state")
+			svc := &gatewayService{githubAppSlug: c.slug}
+			_, err := svc.buildGitHubAppOAuthStartURL("state")
 			if err == nil {
 				t.Fatal("Expected error but got none")
 			}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -63,22 +63,6 @@ func TestNewGitHubAppOAuthStateGeneratesUniqueToken(t *testing.T) {
 	}
 }
 
-func TestVerifyGitHubAppOAuthStateRejectsReplay(t *testing.T) {
-	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
-	now := time.Unix(1700000000, 0)
-
-	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if _, err := svc.verifyGitHubAppOAuthState(rawState, now.Add(time.Minute)); err != nil {
-		t.Fatalf("Unexpected verify error: %v", err)
-	}
-	if _, err := svc.verifyGitHubAppOAuthState(rawState, now.Add(2*time.Minute)); err == nil {
-		t.Fatal("Expected replay error but got none")
-	}
-}
-
 func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
 	now := time.Unix(1700000000, 0)

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -102,12 +102,12 @@ func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 }
 
 func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
-	svc := &gatewayService{githubAppClientID: "Iv1.0123456789abcdef"}
+	svc := &gatewayService{githubAppClientID: "test-github-app-client-id"}
 	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if got != "https://github.com/login/oauth/authorize?client_id=Iv1.0123456789abcdef&state=state-value" {
+	if got != "https://github.com/login/oauth/authorize?client_id=test-github-app-client-id&state=state-value" {
 		t.Fatalf("Unexpected URL: %s", got)
 	}
 }

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -26,6 +26,23 @@ func TestGitHubAppOAuthState(t *testing.T) {
 	}
 }
 
+func TestNewGitHubAppOAuthStateGeneratesUniqueToken(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: "state-secret"}
+	now := time.Unix(1700000000, 0)
+
+	state1, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	state2, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if state1 == state2 {
+		t.Fatal("Expected unique state tokens")
+	}
+}
+
 func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 	svc := &gatewayService{githubAppStateSecret: "state-secret"}
 	now := time.Unix(1700000000, 0)

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -115,6 +115,21 @@ func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
 	}
 }
 
+func TestBuildGitHubAppOAuthStartURLAllowsLocalHTTPRedirectURL(t *testing.T) {
+	svc := &gatewayService{
+		envName:              "local",
+		githubAppClientID:    "test-github-app-client-id",
+		githubAppRedirectURL: "http://localhost:8080/api/v1/code/github-app/oauth/callback",
+	}
+	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "https://github.com/login/oauth/authorize?client_id=test-github-app-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fv1%2Fcode%2Fgithub-app%2Foauth%2Fcallback&state=state-value" {
+		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
 func TestBuildGitHubAppInstallURL(t *testing.T) {
 	svc := &gatewayService{githubAppSlug: "risken-codescan"}
 	got, err := svc.buildGitHubAppInstallURL()

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -112,6 +112,17 @@ func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
 	}
 }
 
+func TestBuildGitHubAppInstallURL(t *testing.T) {
+	svc := &gatewayService{githubAppSlug: "risken-codescan"}
+	got, err := svc.buildGitHubAppInstallURL()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "https://github.com/apps/risken-codescan/installations/select_target" {
+		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
 func TestNormalizeGitHubAppReturnTo(t *testing.T) {
 	got, err := normalizeGitHubAppReturnTo("", 1001)
 	if err != nil {
@@ -147,6 +158,30 @@ func TestBuildGitHubAppOAuthStartURLRejectsMissingClientID(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			svc := &gatewayService{githubAppClientID: c.clientID}
 			_, err := svc.buildGitHubAppOAuthStartURL("state")
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}
+
+func TestBuildGitHubAppInstallURLRejectsInvalidSlug(t *testing.T) {
+	cases := []struct {
+		name string
+		slug string
+	}{
+		{name: "empty"},
+		{name: "blank", slug: "   "},
+		{name: "slash", slug: "owner/risken"},
+		{name: "leading hyphen", slug: "-risken"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{githubAppSlug: c.slug}
+			_, err := svc.buildGitHubAppInstallURL()
 			if err == nil {
 				t.Fatal("Expected error but got none")
 			}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -102,12 +102,12 @@ func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 }
 
 func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
-	svc := &gatewayService{githubAppSlug: "risken-codescan"}
+	svc := &gatewayService{githubAppClientID: "Iv1.0123456789abcdef"}
 	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if got != "https://github.com/apps/risken-codescan/installations/select_target?state=state-value" {
+	if got != "https://github.com/login/oauth/authorize?client_id=Iv1.0123456789abcdef&state=state-value" {
 		t.Fatalf("Unexpected URL: %s", got)
 	}
 }
@@ -135,18 +135,17 @@ func TestNormalizeGitHubAppReturnTo(t *testing.T) {
 	}
 }
 
-func TestBuildGitHubAppOAuthStartURLRejectsInvalidSlug(t *testing.T) {
+func TestBuildGitHubAppOAuthStartURLRejectsMissingClientID(t *testing.T) {
 	cases := []struct {
-		name string
-		slug string
+		name     string
+		clientID string
 	}{
 		{name: "empty"},
-		{name: "slash", slug: "owner/risken"},
-		{name: "leading hyphen", slug: "-risken"},
+		{name: "blank", clientID: "   "},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			svc := &gatewayService{githubAppSlug: c.slug}
+			svc := &gatewayService{githubAppClientID: c.clientID}
 			_, err := svc.buildGitHubAppOAuthStartURL("state")
 			if err == nil {
 				t.Fatal("Expected error but got none")

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -75,6 +75,9 @@ func TestNormalizeGitHubAppReturnTo(t *testing.T) {
 	if _, err := normalizeGitHubAppReturnTo("//attacker.example/path", 1001); err == nil {
 		t.Fatal("Expected protocol-relative URL error but got none")
 	}
+	if _, err := normalizeGitHubAppReturnTo(`/\attacker.example/path`, 1001); err == nil {
+		t.Fatal("Expected backslash URL error but got none")
+	}
 	if _, err := normalizeGitHubAppReturnTo("code/github", 1001); err == nil {
 		t.Fatal("Expected non-relative path error but got none")
 	}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -180,7 +180,7 @@ func TestGitHubAppOAuthCallbackHandlerRedirectsWhenSessionExpired(t *testing.T) 
 	if rec.Code != http.StatusFound {
 		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
 	}
-	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=failed&project_id=1001" {
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=session_expired&project_id=1001" {
 		t.Fatalf("Unexpected Location: %s", got)
 	}
 }

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -101,6 +103,32 @@ func TestBuildGitHubAppInstallURLRejectsInvalidConfig(t *testing.T) {
 			}
 			if strings.TrimSpace(err.Error()) == "" {
 				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}
+
+func TestRedirectGitHubAppOAuthResultRejectsInvalidReturnTo(t *testing.T) {
+	cases := []struct {
+		name     string
+		returnTo string
+	}{
+		{name: "absolute", returnTo: "https://attacker.example"},
+		{name: "backslash", returnTo: `/\attacker.example/path`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{}
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/oauth/callback", nil)
+			rec := httptest.NewRecorder()
+
+			svc.redirectGitHubAppOAuthResult(rec, req, c.returnTo, "success")
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+			}
+			if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=failed" {
+				t.Fatalf("Unexpected Location: %s", got)
 			}
 		})
 	}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -102,12 +102,15 @@ func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
 }
 
 func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
-	svc := &gatewayService{githubAppClientID: "test-github-app-client-id"}
+	svc := &gatewayService{
+		githubAppClientID:    "test-github-app-client-id",
+		githubAppRedirectURL: "https://risken.example/api/v1/code/github-app/oauth/callback",
+	}
 	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if got != "https://github.com/login/oauth/authorize?client_id=test-github-app-client-id&state=state-value" {
+	if got != "https://github.com/login/oauth/authorize?client_id=test-github-app-client-id&redirect_uri=https%3A%2F%2Frisken.example%2Fapi%2Fv1%2Fcode%2Fgithub-app%2Foauth%2Fcallback&state=state-value" {
 		t.Fatalf("Unexpected URL: %s", got)
 	}
 }
@@ -157,6 +160,33 @@ func TestBuildGitHubAppOAuthStartURLRejectsMissingClientID(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			svc := &gatewayService{githubAppClientID: c.clientID}
+			_, err := svc.buildGitHubAppOAuthStartURL("state")
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}
+
+func TestBuildGitHubAppOAuthStartURLRejectsInvalidRedirectURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		redirectURL string
+	}{
+		{name: "empty"},
+		{name: "blank", redirectURL: "   "},
+		{name: "relative", redirectURL: "/api/v1/code/github-app/oauth/callback"},
+		{name: "host missing", redirectURL: "https:///api/v1/code/github-app/oauth/callback"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{
+				githubAppClientID:    "test-github-app-client-id",
+				githubAppRedirectURL: c.redirectURL,
+			}
 			_, err := svc.buildGitHubAppOAuthStartURL("state")
 			if err == nil {
 				t.Fatal("Expected error but got none")

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -131,5 +132,24 @@ func TestRedirectGitHubAppOAuthResultRejectsInvalidReturnTo(t *testing.T) {
 				t.Fatalf("Unexpected Location: %s", got)
 			}
 		})
+	}
+}
+
+func TestGitHubAppOAuthCallbackHandlerRedirectsWhenSessionExpired(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: "12345678901234567890123456789012"}
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", time.Now())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/oauth/callback?state="+url.QueryEscape(rawState)+"&code=oauth-code", nil)
+	rec := httptest.NewRecorder()
+
+	svc.githubAppOAuthCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=failed&project_id=1001" {
+		t.Fatalf("Unexpected Location: %s", got)
 	}
 }


### PR DESCRIPTION
## PRの概要

現在の設計では、GitHub App の Organization / Repository へのインストールは管理者が事前に行い、その後 RISKEN の GitHub 設定で、設定者本人が GitHub 側の対象 Organization / Repository を扱える権限を持つことを user-to-server OAuth で確認します。この PR では、gateway に管理者向けの GitHub App インストールURL取得 endpoint と、設定者向けの User-to-Server OAuth 開始 / callback endpoint を追加し、それぞれの責務を分けています。

管理者向け導線では `GITHUB_APP_SLUG` から `https://github.com/apps/{slug}/installations/select_target` を返し、GitHub App のインストール先 Organization / Repository をGitHub側で選択できるようにします。一方、設定者向け導線では `GITHUB_APP_OAUTH_CLIENT_ID` と `GITHUB_APP_OAUTH_REDIRECT_URL` から `https://github.com/login/oauth/authorize` を組み立て、GitHub App のインストールとは独立して設定者本人の OAuth 認可だけを実施します。GitHub からの callback は通常の `X-XSRF-TOKEN` を持たないため、callback path は通常の CSRF 検証対象から除外し、代わりに HMAC 署名付き state を CSRF 対策として扱います。

```mermaid
sequenceDiagram
    participant Admin as Org管理者
    participant User as RISKEN設定者
    participant Web as RISKEN Web
    participant Gateway as Gateway
    participant GitHub as GitHub
    participant DS as datasource-api

    rect rgb(245, 248, 255)
        Note over Admin,Gateway: 事前インストール
        Admin->>Web: GitHub Appインストール開始
        Web->>Gateway: GET /api/v1/code/github-app/install-url
        Gateway-->>Web: GitHub App install URL
        Web-->>GitHub: /apps/{slug}/installations/select_target へ遷移
        Admin->>GitHub: Organization / RepositoryへGitHub Appをインストール
        GitHub-->>Admin: インストール完了
    end

    rect rgb(245, 255, 247)
        Note over User,DS: RISKEN設定時のuser-to-server検証
        User->>Web: GitHub App方式のGitHub設定を保存・確認
        Web->>Gateway: GET /api/v1/code/github-app/oauth-start
        Gateway->>Gateway: project権限確認と設定者user_id入り署名付きstate生成
        Gateway-->>Web: client_id、redirect_uri、state付きGitHub OAuth開始URL
        Web-->>GitHub: /login/oauth/authorize へ遷移
        User->>GitHub: 設定者本人としてGitHub認可
        GitHub-->>Gateway: OAuth callback(code, state)
        Gateway->>Gateway: state署名・期限・user_id・project権限を検証
        Gateway->>DS: VerifyGitHubAppUser(code)
        DS->>GitHub: OAuth codeを設定者本人のtokenへ交換<br/>同じredirect_uriを送信
        DS->>GitHub: 設定者のGitHubユーザーと対象権限を確認
        DS-->>Gateway: 検証結果
        Gateway-->>Web: success / failed付きで元画面へリダイレクト
    end

    rect rgb(255, 250, 240)
        Note over Web,DS: 設定保存後のserver-to-server検証・同期
        Web->>DS: GitHub設定保存 / installation_id自動解決 / Repository同期
        DS-->>Web: verification_statusと同期済みRepository一覧
    end
```

| 条件 | 変更前 | 変更後 |
|---|---|---|
| 管理者がGitHub Appを事前インストールする場合 | gateway に管理者向けinstall URLを返すendpointがない | `GITHUB_APP_SLUG` から GitHub App install URL を返す |
| 設定者がUser-to-Server OAuthを行う場合 | GitHub AppインストールURLに依存し、インストールとOAuth認可が混在する | `GITHUB_APP_OAUTH_CLIENT_ID` と `GITHUB_APP_OAUTH_REDIRECT_URL` から OAuth authorize URL を返し、設定者本人の認可だけを独立して開始する |
| OAuth redirect URLが未設定または不正な場合 | 認可URLに `redirect_uri` が含まれず、GitHub App設定に依存する | gateway起動時またはURL生成時に拒否し、認可URLに `redirect_uri` を明示する |
| GitHub AppのOAuth callbackを受け取る場合 | callbackを処理するendpointがなく、user-to-server検証へ進めない | state検証後に datasource-api の `VerifyGitHubAppUser` へ委譲する |
| OAuth client IDが設定されているがstate secretが短い場合 | 起動時に検知できない | gateway起動時に32 bytes未満を拒否する |
| callbackに似た別パスへアクセスされた場合 | 通常のCSRF除外対象に含まれない | 引き続き通常のCSRF検証対象として扱う |

## レビュー観点例

- [ ] 管理者向けinstall URLと設定者向けOAuth開始URLを別endpoint・別設定値に分ける責務分離の点
- [ ] gatewayの認可URLとdatasource-apiのtoken exchangeで同じ `redirect_uri` を設定する必要がある点
- [ ] OAuth callbackを通常のCSRF検証から除外し、HMAC署名付きstateをCSRF対策として扱う設計の妥当性の点
- [ ] stateに含める `project_id`、`github_setting_id`、`user_id`、`return_to`、`random`、`expires_at` の粒度がcallback検証に対して過不足ない点
- [ ] `return_to` を相対パスに限定することで、GitHub callback後のオープンリダイレクトを防げている点
