### PR TITLE
GitHub App設定者向けOAuthフローを追加

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -366,6 +366,7 @@ func isHumanAccess(u *requestUser) bool {
 var ignoreURI4CSRF = []string{
 	"/healthz",
 	"/api/v1/signin",
+	githubAppOAuthCallbackPath,
 }
 
 func shouldVerifyCSRFTokenURI(uri string) bool {

--- a/authorizer_test.go
+++ b/authorizer_test.go
@@ -778,6 +778,16 @@ func TestShouldVerifyCSRFTokenURI(t *testing.T) {
 			input: "/api/v1/signin/",
 			want:  false,
 		},
+		{
+			name:  "github app callback is ignored",
+			input: "/api/v1/code/github-app/oauth/callback",
+			want:  false,
+		},
+		{
+			name:  "github app callback prefix is not ignored",
+			input: "/api/v1/code/github-app/oauth/callback-other",
+			want:  true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c
+	github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0
+	github.com/ca-risken/datasource-api v0.16.1-0.20260629092252-84670740cab7
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c h1:RZmYcPdyxzgFhLZrPpzmStLUeghYwAGeM/i/3N/gh04=
-github.com/ca-risken/datasource-api v0.16.1-0.20260526095024-48ed174f5d3c/go.mod h1:0oGPPu+LrjnXNSJF73FlE5pJ60z1h/h5644TkERCElc=
+github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0 h1:vtyk9VlwbfQzcwxQQCQXMlxKH82ocwDVNgSxFy47w3o=
+github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0/go.mod h1:xktE2epQWUc2GZom/b09CxMWk62cosU90R4dV7zGWo0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0 h1:vtyk9VlwbfQzcwxQQCQXMlxKH82ocwDVNgSxFy47w3o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260623081219-ec924c5cdac0/go.mod h1:xktE2epQWUc2GZom/b09CxMWk62cosU90R4dV7zGWo0=
+github.com/ca-risken/datasource-api v0.16.1-0.20260629092252-84670740cab7 h1:qxIobowqOjUX3k6ZduLolubn4C1VcVAxfcXNdtFZdXY=
+github.com/ca-risken/datasource-api v0.16.1-0.20260629092252-84670740cab7/go.mod h1:HtB67lg18k0n3hhCgxfz9qYPQUPWjprArcpCDlig4fM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/main.go
+++ b/main.go
@@ -42,14 +42,17 @@ type AppConfig struct {
 	UserIdpKey         string   `split_words:"true" default:"preferred_username"`
 	Region             string   `default:"ap-northeast-1"`
 
-	CoreAddr             string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
-	DataSourceAPISvcAddr string `required:"true" split_words:"true" default:"datasource-api.datasource.svc.cluster.local:8081"`
-	MaxRequestBodyBytes  int64  `split_words:"true" default:"1048576"`
-	ReadHeaderTimeoutSec int    `split_words:"true" default:"5"`
-	ReadTimeoutSec       int    `split_words:"true" default:"30"`
-	WriteTimeoutSec      int    `split_words:"true" default:"30"`
-	IdleTimeoutSec       int    `split_words:"true" default:"120"`
-	MaxHeaderBytes       int    `split_words:"true" default:"1048576"`
+	CoreAddr                  string `required:"true" split_words:"true" default:"core.core.svc.cluster.local:8080"`
+	DataSourceAPISvcAddr      string `required:"true" split_words:"true" default:"datasource-api.datasource.svc.cluster.local:8081"`
+	MaxRequestBodyBytes       int64  `split_words:"true" default:"1048576"`
+	ReadHeaderTimeoutSec      int    `split_words:"true" default:"5"`
+	ReadTimeoutSec            int    `split_words:"true" default:"30"`
+	WriteTimeoutSec           int    `split_words:"true" default:"30"`
+	IdleTimeoutSec            int    `split_words:"true" default:"120"`
+	MaxHeaderBytes            int    `split_words:"true" default:"1048576"`
+	GithubAppOAuthClientID    string `split_words:"true"`
+	GithubAppOAuthRedirectURL string `split_words:"true"`
+	GithubAppStateSecret      string `split_words:"true"`
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -50,9 +50,9 @@ type AppConfig struct {
 	WriteTimeoutSec           int    `split_words:"true" default:"30"`
 	IdleTimeoutSec            int    `split_words:"true" default:"120"`
 	MaxHeaderBytes            int    `split_words:"true" default:"1048576"`
-	GithubAppOAuthClientID    string `split_words:"true"`
-	GithubAppOAuthRedirectURL string `split_words:"true"`
-	GithubAppStateSecret      string `split_words:"true"`
+	GithubAppOAuthClientID    string `envconfig:"GITHUB_APP_OAUTH_CLIENT_ID"`
+	GithubAppOAuthRedirectURL string `envconfig:"GITHUB_APP_OAUTH_REDIRECT_URL"`
+	GithubAppStateSecret      string `envconfig:"GITHUB_APP_STATE_SECRET"`
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -37,3 +37,90 @@ func TestNewHTTPServer(t *testing.T) {
 		t.Fatalf("unexpected max header bytes: %d", server.MaxHeaderBytes)
 	}
 }
+
+func TestValidateGatewayConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		conf       *AppConfig
+		wantErrMsg string
+	}{
+		{
+			name: "github app disabled",
+			conf: &AppConfig{},
+		},
+		{
+			name: "github app disabled with short state secret",
+			conf: &AppConfig{
+				GithubAppStateSecret: "short",
+			},
+			wantErrMsg: "github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured",
+		},
+		{
+			name: "github app enabled with strong state secret",
+			conf: &AppConfig{
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "https://risken.example/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+		},
+		{
+			name: "github app enabled with short state secret",
+			conf: &AppConfig{
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "https://risken.example/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "short",
+			},
+			wantErrMsg: "github app state secret must be at least 32 bytes when github app oauth client id is configured",
+		},
+		{
+			name: "github app enabled without redirect url",
+			conf: &AppConfig{
+				GithubAppOAuthClientID: "test-github-app-client-id",
+				GithubAppStateSecret:   "12345678901234567890123456789012",
+			},
+			wantErrMsg: "github app oauth redirect url is required when github app oauth client id is configured",
+		},
+		{
+			name: "github app enabled with relative redirect url",
+			conf: &AppConfig{
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+			wantErrMsg: "github app oauth redirect url must be an absolute URL",
+		},
+		{
+			name: "github app enabled with local http redirect url",
+			conf: &AppConfig{
+				EnvName:                   "local",
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "http://localhost:8080/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+		},
+		{
+			name: "github app enabled with production http redirect url",
+			conf: &AppConfig{
+				EnvName:                   "prod",
+				GithubAppOAuthClientID:    "test-github-app-client-id",
+				GithubAppOAuthRedirectURL: "http://localhost:8080/api/v1/code/github-app/oauth/callback",
+				GithubAppStateSecret:      "12345678901234567890123456789012",
+			},
+			wantErrMsg: "github app oauth redirect url must use https except local localhost",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateGatewayConfig(c.conf)
+			if c.wantErrMsg != "" && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if c.wantErrMsg == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c.wantErrMsg != "" && err.Error() != c.wantErrMsg {
+				t.Fatalf("unexpected error. want=%q, got=%q", c.wantErrMsg, err.Error())
+			}
+		})
+	}
+}

--- a/router.go
+++ b/router.go
@@ -324,11 +324,13 @@ func newRouter(svc *gatewayService) *chi.Mux {
 			r.Group(func(r chi.Router) {
 				// project any
 				r.Get("/list-datasource", svc.listDataSourceCodeHandler)
+				r.Get("/github-app/oauth/callback", svc.githubAppOAuthCallbackHandler)
 			})
 			r.Group(func(r chi.Router) {
 				r.Use(svc.authzWithProject)
 				r.Get("/list-github-setting", svc.listGitHubSettingCodeHandler)
 				r.Get("/list-gitleaks-cache", svc.listGitleaksCacheCodeHandler)
+				r.Get("/github-app/oauth-start", svc.githubAppOAuthStartHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))
 					r.Post("/put-github-setting", svc.putGitHubSettingCodeHandler)

--- a/service.go
+++ b/service.go
@@ -33,37 +33,45 @@ import (
 const (
 	successJSONKey = "data"
 	errorJSONKey   = "error"
+
+	minGitHubAppStateSecretBytes = 32
 )
 
 type gatewayService struct {
-	envName            string
-	port               string
-	uidHeader          string
-	oidcDataHeader     string
-	sessionCookieName  []string
-	sessionTimeoutSec  int
-	findingClient      finding.FindingServiceClient
-	iamClient          iam.IAMServiceClient
-	projectClient      project.ProjectServiceClient
-	alertClient        alert.AlertServiceClient
-	reportClient       report.ReportServiceClient
-	organizationClient organization.OrganizationServiceClient
-	org_iamClient      org_iam.OrgIAMServiceClient
-	org_alertClient    org_alert.OrgAlertServiceClient
-	awsClient          aws.AWSServiceClient
-	osintClient        osint.OsintServiceClient
-	diagnosisClient    diagnosis.DiagnosisServiceClient
-	codeClient         code.CodeServiceClient
-	googleClient       google.GoogleServiceClient
-	azureClient        azure.AzureServiceClient
-	aiClient           ai.AIServiceClient
-	claimsClient       claimsInterface
-	datasourceClient   datasource.DataSourceServiceClient
+	envName              string
+	port                 string
+	uidHeader            string
+	oidcDataHeader       string
+	sessionCookieName    []string
+	sessionTimeoutSec    int
+	githubAppClientID    string
+	githubAppRedirectURL string
+	githubAppStateSecret string
+	findingClient        finding.FindingServiceClient
+	iamClient            iam.IAMServiceClient
+	projectClient        project.ProjectServiceClient
+	alertClient          alert.AlertServiceClient
+	reportClient         report.ReportServiceClient
+	organizationClient   organization.OrganizationServiceClient
+	org_iamClient        org_iam.OrgIAMServiceClient
+	org_alertClient      org_alert.OrgAlertServiceClient
+	awsClient            aws.AWSServiceClient
+	osintClient          osint.OsintServiceClient
+	diagnosisClient      diagnosis.DiagnosisServiceClient
+	codeClient           code.CodeServiceClient
+	googleClient         google.GoogleServiceClient
+	azureClient          azure.AzureServiceClient
+	aiClient             ai.AIServiceClient
+	claimsClient         claimsInterface
+	datasourceClient     datasource.DataSourceServiceClient
 }
 
 func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, error) {
 	if conf.Debug {
 		appLogger.Level(logging.DebugLevel)
+	}
+	if err := validateGatewayConfig(conf); err != nil {
+		return nil, err
 	}
 
 	coreConn, err := getGRPCConn(ctx, conf.CoreAddr)
@@ -77,30 +85,55 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		return nil, err
 	}
 	return &gatewayService{
-		envName:            conf.EnvName,
-		port:               conf.Port,
-		uidHeader:          conf.UserIdentityHeader,
-		oidcDataHeader:     conf.OidcDataHeader,
-		sessionCookieName:  conf.SessionCookieName,
-		sessionTimeoutSec:  conf.SessionTimeoutSec,
-		findingClient:      finding.NewFindingServiceClient(coreConn),
-		iamClient:          iam.NewIAMServiceClient(coreConn),
-		projectClient:      project.NewProjectServiceClient(coreConn),
-		alertClient:        alert.NewAlertServiceClient(coreConn),
-		reportClient:       report.NewReportServiceClient(coreConn),
-		organizationClient: organization.NewOrganizationServiceClient(coreConn),
-		org_iamClient:      org_iam.NewOrgIAMServiceClient(coreConn),
-		org_alertClient:    org_alert.NewOrgAlertServiceClient(coreConn),
-		awsClient:          aws.NewAWSServiceClient(datasourceConn),
-		osintClient:        osint.NewOsintServiceClient(datasourceConn),
-		diagnosisClient:    diagnosis.NewDiagnosisServiceClient(datasourceConn),
-		codeClient:         code.NewCodeServiceClient(datasourceConn),
-		googleClient:       google.NewGoogleServiceClient(datasourceConn),
-		azureClient:        azure.NewAzureServiceClient(datasourceConn),
-		aiClient:           ai.NewAIServiceClient(coreConn),
-		claimsClient:       newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
-		datasourceClient:   datasource.NewDataSourceServiceClient(datasourceConn),
+		envName:              conf.EnvName,
+		port:                 conf.Port,
+		uidHeader:            conf.UserIdentityHeader,
+		oidcDataHeader:       conf.OidcDataHeader,
+		sessionCookieName:    conf.SessionCookieName,
+		sessionTimeoutSec:    conf.SessionTimeoutSec,
+		githubAppClientID:    conf.GithubAppOAuthClientID,
+		githubAppRedirectURL: conf.GithubAppOAuthRedirectURL,
+		githubAppStateSecret: conf.GithubAppStateSecret,
+		findingClient:        finding.NewFindingServiceClient(coreConn),
+		iamClient:            iam.NewIAMServiceClient(coreConn),
+		projectClient:        project.NewProjectServiceClient(coreConn),
+		alertClient:          alert.NewAlertServiceClient(coreConn),
+		reportClient:         report.NewReportServiceClient(coreConn),
+		organizationClient:   organization.NewOrganizationServiceClient(coreConn),
+		org_iamClient:        org_iam.NewOrgIAMServiceClient(coreConn),
+		org_alertClient:      org_alert.NewOrgAlertServiceClient(coreConn),
+		awsClient:            aws.NewAWSServiceClient(datasourceConn),
+		osintClient:          osint.NewOsintServiceClient(datasourceConn),
+		diagnosisClient:      diagnosis.NewDiagnosisServiceClient(datasourceConn),
+		codeClient:           code.NewCodeServiceClient(datasourceConn),
+		googleClient:         google.NewGoogleServiceClient(datasourceConn),
+		azureClient:          azure.NewAzureServiceClient(datasourceConn),
+		aiClient:             ai.NewAIServiceClient(coreConn),
+		claimsClient:         newClaimsClient(conf.Region, conf.UserIdpKey, conf.IdpProviderName, conf.VerifyIDToken),
+		datasourceClient:     datasource.NewDataSourceServiceClient(datasourceConn),
 	}, nil
+}
+
+func validateGatewayConfig(conf *AppConfig) error {
+	if conf.GithubAppOAuthClientID == "" {
+		if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
+			return errors.New("github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured")
+		}
+		return nil
+	}
+	if conf.GithubAppOAuthRedirectURL == "" {
+		return errors.New("github app oauth redirect url is required when github app oauth client id is configured")
+	}
+	if _, err := validateGitHubAppOAuthRedirectURL(conf.GithubAppOAuthRedirectURL, isLocalEnv(conf.EnvName)); err != nil {
+		return err
+	}
+	if conf.GithubAppStateSecret == "" {
+		return errors.New("github app state secret is required when github app oauth client id is configured")
+	}
+	if len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
+		return errors.New("github app state secret must be at least 32 bytes when github app oauth client id is configured")
+	}
+	return nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ca-risken/datasource-api/proto/code"
+)
+
+const (
+	githubAppOAuthCallbackPath = "/api/v1/code/github-app/oauth/callback"
+	githubAppStateTTL          = 10 * time.Minute
+	githubAppOAuthAuthorizeURL = "https://github.com/login/oauth/authorize"
+)
+
+type githubAppOAuthState struct {
+	ProjectID       uint32 `json:"project_id"`
+	GithubSettingID uint32 `json:"github_setting_id"`
+	UserID          uint32 `json:"user_id"`
+	ReturnTo        string `json:"return_to"`
+	Random          string `json:"random"`
+	ExpiresAt       int64  `json:"expires_at"`
+}
+
+func (g *gatewayService) githubAppOAuthStartHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	u, err := getRequestUser(r)
+	if err != nil || !isHumanAccess(u) {
+		writeResponse(ctx, w, http.StatusUnauthorized, map[string]any{errorJSONKey: "Unauthenticated"})
+		return
+	}
+	projectID, err := parseRequiredUint32(r, "project_id")
+	if err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	githubSettingID, err := parseRequiredUint32(r, "github_setting_id")
+	if err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	returnTo, err := normalizeGitHubAppReturnTo(r.URL.Query().Get("return_to"), projectID)
+	if err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: err.Error()})
+		return
+	}
+	state, err := g.newGitHubAppOAuthState(projectID, githubSettingID, u.userID, returnTo, time.Now())
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to create github app oauth state: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth is not configured"})
+		return
+	}
+	oauthURL, err := g.buildGitHubAppOAuthStartURL(state)
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to build github app oauth start url: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App OAuth start URL is not configured"})
+		return
+	}
+	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": oauthURL}})
+}
+
+func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	state, err := g.verifyGitHubAppOAuthState(r.URL.Query().Get("state"), time.Now())
+	if err != nil {
+		appLogger.Warnf(ctx, "Invalid github app oauth state: err=%+v", err)
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]any{errorJSONKey: "Invalid GitHub App OAuth state"})
+		return
+	}
+	u, err := getRequestUser(r)
+	if err != nil || !isHumanAccess(u) {
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "session_expired")
+		return
+	}
+	if state.UserID != u.userID {
+		appLogger.Warnf(ctx, "GitHub App OAuth state user mismatch: state_user_id=%d, request_user_id=%d", state.UserID, u.userID)
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "unauthorized")
+		return
+	}
+	if !g.isAuthorizedProject(ctx, u.userID, state.ProjectID, r.URL.Path) {
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "unauthorized")
+		return
+	}
+	oauthCode := r.URL.Query().Get("code")
+	if strings.TrimSpace(oauthCode) == "" {
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "failed")
+		return
+	}
+	if _, err := g.codeClient.VerifyGitHubAppUser(ctx, &code.VerifyGitHubAppUserRequest{
+		ProjectId:       state.ProjectID,
+		GithubSettingId: state.GithubSettingID,
+		Code:            oauthCode,
+	}); err != nil {
+		appLogger.Warnf(ctx, "Failed to verify github app oauth user: project_id=%d, github_setting_id=%d, err=%+v", state.ProjectID, state.GithubSettingID, err)
+		g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "failed")
+		return
+	}
+	g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "success")
+}
+
+func parseRequiredUint32(r *http.Request, name string) (uint32, error) {
+	value := r.URL.Query().Get(name)
+	if value == "" {
+		return 0, fmt.Errorf("required %s", name)
+	}
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil || parsed == 0 {
+		return 0, fmt.Errorf("invalid %s", name)
+	}
+	return uint32(parsed), nil
+}
+
+func normalizeGitHubAppReturnTo(returnTo string, projectID uint32) (string, error) {
+	if returnTo == "" {
+		return fmt.Sprintf("/code/github?project_id=%d", projectID), nil
+	}
+	if err := validateGitHubAppReturnTo(returnTo); err != nil {
+		return "", err
+	}
+	return returnTo, nil
+}
+
+func validateGitHubAppReturnTo(returnTo string) error {
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		return err
+	}
+	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(returnTo, "/") || strings.HasPrefix(returnTo, "//") || strings.ContainsRune(returnTo, '\\') {
+		return errors.New("return_to must be a relative path")
+	}
+	return nil
+}
+
+func (g *gatewayService) newGitHubAppOAuthState(projectID, githubSettingID, userID uint32, returnTo string, now time.Time) (string, error) {
+	randomBytes := make([]byte, 16)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
+	state := &githubAppOAuthState{
+		ProjectID:       projectID,
+		GithubSettingID: githubSettingID,
+		UserID:          userID,
+		ReturnTo:        returnTo,
+		Random:          base64.RawURLEncoding.EncodeToString(randomBytes),
+		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
+	}
+	return g.signGitHubAppOAuthState(state)
+}
+
+func (g *gatewayService) signGitHubAppOAuthState(state *githubAppOAuthState) (string, error) {
+	if g.githubAppStateSecret == "" {
+		return "", errors.New("github app state secret is required")
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signature := signGitHubAppState(encodedPayload, g.githubAppStateSecret)
+	return encodedPayload + "." + signature, nil
+}
+
+func (g *gatewayService) verifyGitHubAppOAuthState(rawState string, now time.Time) (*githubAppOAuthState, error) {
+	if g.githubAppStateSecret == "" {
+		return nil, errors.New("github app state secret is required")
+	}
+	parts := strings.Split(rawState, ".")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid state format")
+	}
+	expectedSignature := signGitHubAppState(parts[0], g.githubAppStateSecret)
+	if !hmac.Equal([]byte(expectedSignature), []byte(parts[1])) {
+		return nil, errors.New("invalid state signature")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	state := &githubAppOAuthState{}
+	if err := json.Unmarshal(payload, state); err != nil {
+		return nil, err
+	}
+	if state.ProjectID == 0 || state.GithubSettingID == 0 || state.UserID == 0 || state.ReturnTo == "" || state.Random == "" {
+		return nil, errors.New("invalid state payload")
+	}
+	if err := validateGitHubAppReturnTo(state.ReturnTo); err != nil {
+		return nil, err
+	}
+	if now.Unix() > state.ExpiresAt {
+		return nil, errors.New("expired state")
+	}
+	return state, nil
+}
+
+func signGitHubAppState(payload, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (g *gatewayService) buildGitHubAppOAuthStartURL(state string) (string, error) {
+	clientID := strings.TrimSpace(g.githubAppClientID)
+	if clientID == "" {
+		return "", errors.New("github app oauth client id is required")
+	}
+	redirectURL, err := validateGitHubAppOAuthRedirectURL(g.githubAppRedirectURL, isLocalEnv(g.envName))
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(githubAppOAuthAuthorizeURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURL)
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func validateGitHubAppOAuthRedirectURL(redirectURL string, allowLocalHTTP bool) (string, error) {
+	redirectURL = strings.TrimSpace(redirectURL)
+	if redirectURL == "" {
+		return "", errors.New("github app oauth redirect url is required")
+	}
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Host == "" {
+		return "", errors.New("github app oauth redirect url must be an absolute URL")
+	}
+	if u.Scheme == "https" {
+		return redirectURL, nil
+	}
+	if u.Scheme == "http" && allowLocalHTTP && isLocalHost(u.Hostname()) {
+		return redirectURL, nil
+	}
+	return "", errors.New("github app oauth redirect url must use https except local localhost")
+}
+
+func isLocalEnv(envName string) bool {
+	return strings.EqualFold(strings.TrimSpace(envName), "local")
+}
+
+func isLocalHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func (g *gatewayService) redirectGitHubAppOAuthResult(w http.ResponseWriter, r *http.Request, returnTo, result string) {
+	if err := validateGitHubAppReturnTo(returnTo); err != nil {
+		http.Redirect(w, r, "/code/github?github_app_oauth=failed", http.StatusFound)
+		return
+	}
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		http.Redirect(w, r, "/code/github?github_app_oauth=failed", http.StatusFound)
+		return
+	}
+	q := u.Query()
+	q.Set("github_app_oauth", result)
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ca-risken/core/proto/iam"
+	iammocks "github.com/ca-risken/core/proto/iam/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+const testGitHubAppStateSecret = "12345678901234567890123456789012"
+
+func newGitHubAppOAuthCallbackRequest(t *testing.T, svc *gatewayService, userID uint32) *http.Request {
+	t.Helper()
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", time.Now())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/oauth/callback?state="+url.QueryEscape(rawState)+"&code=oauth-code", nil)
+	if userID != 0 {
+		req = req.WithContext(context.WithValue(req.Context(), userKey, &requestUser{userID: userID}))
+	}
+	return req
+}
+
+func TestGitHubAppOAuthState(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	now := time.Unix(1700000000, 0)
+
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	state, err := svc.verifyGitHubAppOAuthState(rawState, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("Unexpected verify error: %v", err)
+	}
+	if state.ProjectID != 1001 || state.GithubSettingID != 10 || state.UserID != 20 || state.ReturnTo != "/code/github?project_id=1001" {
+		t.Fatalf("Unexpected state: %+v", state)
+	}
+}
+
+func TestNewGitHubAppOAuthStateGeneratesUniqueToken(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	now := time.Unix(1700000000, 0)
+
+	state1, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	state2, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if state1 == state2 {
+		t.Fatal("Expected unique state tokens")
+	}
+}
+
+func TestVerifyGitHubAppOAuthStateRejectsInvalidState(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	now := time.Unix(1700000000, 0)
+	rawState, err := svc.newGitHubAppOAuthState(1001, 10, 20, "/code/github?project_id=1001", now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	invalidReturnToState, err := svc.signGitHubAppOAuthState(&githubAppOAuthState{
+		ProjectID:       1001,
+		GithubSettingID: 10,
+		UserID:          20,
+		ReturnTo:        `/\attacker.example/path`,
+		Random:          "test-random",
+		ExpiresAt:       now.Add(githubAppStateTTL).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		state string
+		now   time.Time
+	}{
+		{name: "invalid format", state: "invalid", now: now},
+		{name: "invalid signature", state: rawState + "x", now: now},
+		{name: "invalid return_to", state: invalidReturnToState, now: now},
+		{name: "expired", state: rawState, now: now.Add(githubAppStateTTL + time.Second)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := svc.verifyGitHubAppOAuthState(c.state, c.now); err == nil {
+				t.Fatal("Expected error but got none")
+			}
+		})
+	}
+}
+
+func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
+	svc := &gatewayService{
+		githubAppClientID:    "test-github-app-client-id",
+		githubAppRedirectURL: "https://risken.example/api/v1/code/github-app/oauth/callback",
+	}
+	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "https://github.com/login/oauth/authorize?client_id=test-github-app-client-id&redirect_uri=https%3A%2F%2Frisken.example%2Fapi%2Fv1%2Fcode%2Fgithub-app%2Foauth%2Fcallback&state=state-value" {
+		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
+func TestBuildGitHubAppOAuthStartURLAllowsLocalHTTPRedirectURL(t *testing.T) {
+	svc := &gatewayService{
+		envName:              "local",
+		githubAppClientID:    "test-github-app-client-id",
+		githubAppRedirectURL: "http://localhost:8080/api/v1/code/github-app/oauth/callback",
+	}
+	got, err := svc.buildGitHubAppOAuthStartURL("state-value")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "https://github.com/login/oauth/authorize?client_id=test-github-app-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fv1%2Fcode%2Fgithub-app%2Foauth%2Fcallback&state=state-value" {
+		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
+func TestNormalizeGitHubAppReturnTo(t *testing.T) {
+	got, err := normalizeGitHubAppReturnTo("", 1001)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "/code/github?project_id=1001" {
+		t.Fatalf("Unexpected return_to: %s", got)
+	}
+
+	if _, err := normalizeGitHubAppReturnTo("https://attacker.example", 1001); err == nil {
+		t.Fatal("Expected absolute URL error but got none")
+	}
+	if _, err := normalizeGitHubAppReturnTo("//attacker.example/path", 1001); err == nil {
+		t.Fatal("Expected protocol-relative URL error but got none")
+	}
+	if _, err := normalizeGitHubAppReturnTo(`/\attacker.example/path`, 1001); err == nil {
+		t.Fatal("Expected backslash URL error but got none")
+	}
+	if _, err := normalizeGitHubAppReturnTo("code/github", 1001); err == nil {
+		t.Fatal("Expected non-relative path error but got none")
+	}
+}
+
+func TestBuildGitHubAppOAuthStartURLRejectsMissingClientID(t *testing.T) {
+	cases := []struct {
+		name     string
+		clientID string
+	}{
+		{name: "empty"},
+		{name: "blank", clientID: "   "},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{githubAppClientID: c.clientID}
+			_, err := svc.buildGitHubAppOAuthStartURL("state")
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}
+
+func TestBuildGitHubAppOAuthStartURLRejectsInvalidRedirectURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		redirectURL string
+	}{
+		{name: "empty"},
+		{name: "blank", redirectURL: "   "},
+		{name: "relative", redirectURL: "/api/v1/code/github-app/oauth/callback"},
+		{name: "host missing", redirectURL: "https:///api/v1/code/github-app/oauth/callback"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{
+				githubAppClientID:    "test-github-app-client-id",
+				githubAppRedirectURL: c.redirectURL,
+			}
+			_, err := svc.buildGitHubAppOAuthStartURL("state")
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}
+
+func TestRedirectGitHubAppOAuthResultRejectsInvalidReturnTo(t *testing.T) {
+	cases := []struct {
+		name     string
+		returnTo string
+	}{
+		{name: "absolute", returnTo: "https://attacker.example"},
+		{name: "backslash", returnTo: `/\attacker.example/path`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{}
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/oauth/callback", nil)
+			rec := httptest.NewRecorder()
+
+			svc.redirectGitHubAppOAuthResult(rec, req, c.returnTo, "success")
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+			}
+			if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=failed" {
+				t.Fatalf("Unexpected Location: %s", got)
+			}
+		})
+	}
+}
+
+func TestGitHubAppOAuthCallbackHandlerRedirectsWhenSessionExpired(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	req := newGitHubAppOAuthCallbackRequest(t, svc, 0)
+	rec := httptest.NewRecorder()
+
+	svc.githubAppOAuthCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=session_expired&project_id=1001" {
+		t.Fatalf("Unexpected Location: %s", got)
+	}
+}
+
+func TestGitHubAppOAuthCallbackHandlerRedirectsWhenUserMismatch(t *testing.T) {
+	svc := &gatewayService{githubAppStateSecret: testGitHubAppStateSecret}
+	req := newGitHubAppOAuthCallbackRequest(t, svc, 21)
+	rec := httptest.NewRecorder()
+
+	svc.githubAppOAuthCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=unauthorized&project_id=1001" {
+		t.Fatalf("Unexpected Location: %s", got)
+	}
+}
+
+func TestGitHubAppOAuthCallbackHandlerRedirectsWhenProjectUnauthorized(t *testing.T) {
+	iamMock := iammocks.NewIAMServiceClient(t)
+	iamMock.On("IsAuthorized", mock.Anything, mock.Anything).Return(&iam.IsAuthorizedResponse{Ok: false}, nil).Once()
+	svc := &gatewayService{
+		githubAppStateSecret: testGitHubAppStateSecret,
+		iamClient:            iamMock,
+	}
+	req := newGitHubAppOAuthCallbackRequest(t, svc, 20)
+	rec := httptest.NewRecorder()
+
+	svc.githubAppOAuthCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusFound, rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/code/github?github_app_oauth=unauthorized&project_id=1001" {
+		t.Fatalf("Unexpected Location: %s", got)
+	}
+}


### PR DESCRIPTION
## PRの概要

GitHub App 設定時に、RISKEN の設定者が GitHub 側でも対象リポジトリを扱えるユーザーか確認するため、Gateway に User-to-Server OAuth の開始 endpoint と callback endpoint を追加します。

この PR は管理者向けの GitHub App install URL 生成は含めず、設定者 OAuth の state 生成・検証・datasource-api への検証委譲だけを扱います。

Gateway は OAuth code を永続化せず、HMAC 署名付き state で RISKEN user / project / GitHub setting / return_to を紐付けたうえで、callback 後に datasource-api の VerifyGitHubAppUser へ code を渡します。

```mermaid
sequenceDiagram
    participant Web as RISKEN Web
    participant Gateway as Gateway
    participant GitHub as GitHub OAuth
    participant DS as datasource-api

    Web->>Gateway: GET /api/v1/code/github-app/oauth-start
    Gateway->>Gateway: project 認可と state 生成
    Gateway-->>Web: GitHub OAuth authorize URL
    Web->>GitHub: 設定者が OAuth 認可
    GitHub-->>Gateway: callback(code, state)
    Gateway->>Gateway: state / user_id / project 認可を検証
    Gateway->>DS: VerifyGitHubAppUser(code)
    DS-->>Gateway: GitHub user / 権限検証結果
    Gateway-->>Web: return_to へ結果付き redirect
```

また、OAuth redirect_uri を gateway の設定値として明示的に authorize URL に含めるため、起動時に client_id・redirect_url・state_secret の組み合わせを検証します。
本番相当では HTTPS の redirect URL のみを許可し、ローカル検証では localhost / 127.0.0.1 / ::1 の HTTP だけを例外として許可します。

## レビュー観点例

- [ ] OAuth callback を CSRF 検証対象外にする代わりに、HMAC 署名付き state、TTL、user_id、project 認可で補完している点
- [ ] redirect_uri を gateway 設定値から明示的に付与し、本番では HTTPS のみ、local では localhost HTTP のみを許可している点
- [ ] Gateway は OAuth code を保存せず、GitHub ユーザー権限の検証を datasource-api の VerifyGitHubAppUser に委譲している点
- [ ] state にランダム値を含める一方、サーバー側の使い捨て管理は行わず、TTL と GitHub 認可コードの単回利用を前提にしている点
