### PR TITLE
GitHub App install URL endpointを追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ type AppConfig struct {
 	GithubAppOAuthClientID    string `envconfig:"GITHUB_APP_OAUTH_CLIENT_ID"`
 	GithubAppOAuthRedirectURL string `envconfig:"GITHUB_APP_OAUTH_REDIRECT_URL"`
 	GithubAppStateSecret      string `envconfig:"GITHUB_APP_STATE_SECRET"`
+	GithubAppSlug             string `envconfig:"GITHUB_APP_SLUG"`
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -49,6 +49,19 @@ func TestValidateGatewayConfig(t *testing.T) {
 			conf: &AppConfig{},
 		},
 		{
+			name: "github app slug configured",
+			conf: &AppConfig{
+				GithubAppSlug: "codescan-app-test",
+			},
+		},
+		{
+			name: "github app slug invalid",
+			conf: &AppConfig{
+				GithubAppSlug: "owner/app",
+			},
+			wantErrMsg: "github app slug is invalid",
+		},
+		{
 			name: "github app disabled with short state secret",
 			conf: &AppConfig{
 				GithubAppStateSecret: "short",

--- a/router.go
+++ b/router.go
@@ -330,6 +330,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(svc.authzWithProject)
 				r.Get("/list-github-setting", svc.listGitHubSettingCodeHandler)
 				r.Get("/list-gitleaks-cache", svc.listGitleaksCacheCodeHandler)
+				r.Get("/github-app/install-url", svc.githubAppInstallURLHandler)
 				r.Get("/github-app/oauth-start", svc.githubAppOAuthStartHandler)
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.AllowContentType(contenTypeJSON))

--- a/service.go
+++ b/service.go
@@ -47,6 +47,7 @@ type gatewayService struct {
 	githubAppClientID    string
 	githubAppRedirectURL string
 	githubAppStateSecret string
+	githubAppSlug        string
 	findingClient        finding.FindingServiceClient
 	iamClient            iam.IAMServiceClient
 	projectClient        project.ProjectServiceClient
@@ -94,6 +95,7 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 		githubAppClientID:    conf.GithubAppOAuthClientID,
 		githubAppRedirectURL: conf.GithubAppOAuthRedirectURL,
 		githubAppStateSecret: conf.GithubAppStateSecret,
+		githubAppSlug:        conf.GithubAppSlug,
 		findingClient:        finding.NewFindingServiceClient(coreConn),
 		iamClient:            iam.NewIAMServiceClient(coreConn),
 		projectClient:        project.NewProjectServiceClient(coreConn),
@@ -115,6 +117,9 @@ func newGatewayService(ctx context.Context, conf *AppConfig) (*gatewayService, e
 }
 
 func validateGatewayConfig(conf *AppConfig) error {
+	if conf.GithubAppSlug != "" && !isValidGitHubAppSlug(conf.GithubAppSlug) {
+		return errors.New("github app slug is invalid")
+	}
 	if conf.GithubAppOAuthClientID == "" {
 		if conf.GithubAppStateSecret != "" && len(conf.GithubAppStateSecret) < minGitHubAppStateSecretBytes {
 			return errors.New("github app state secret must be empty or at least 32 bytes when github app oauth client id is not configured")

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -21,6 +21,7 @@ const (
 	githubAppOAuthCallbackPath = "/api/v1/code/github-app/oauth/callback"
 	githubAppStateTTL          = 10 * time.Minute
 	githubAppOAuthAuthorizeURL = "https://github.com/login/oauth/authorize"
+	githubAppInstallURLFormat  = "https://github.com/apps/%s/installations/select_target"
 )
 
 type githubAppOAuthState struct {
@@ -30,6 +31,17 @@ type githubAppOAuthState struct {
 	ReturnTo        string `json:"return_to"`
 	Random          string `json:"random"`
 	ExpiresAt       int64  `json:"expires_at"`
+}
+
+func (g *gatewayService) githubAppInstallURLHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	installURL, err := g.buildGitHubAppInstallURL()
+	if err != nil {
+		appLogger.Errorf(ctx, "Failed to build github app install url: err=%+v", err)
+		writeResponse(ctx, w, http.StatusServiceUnavailable, map[string]any{errorJSONKey: "GitHub App install URL is not configured"})
+		return
+	}
+	writeResponse(ctx, w, http.StatusOK, map[string]any{successJSONKey: map[string]string{"url": installURL}})
 }
 
 func (g *gatewayService) githubAppOAuthStartHandler(w http.ResponseWriter, r *http.Request) {
@@ -106,6 +118,36 @@ func (g *gatewayService) githubAppOAuthCallbackHandler(w http.ResponseWriter, r 
 		return
 	}
 	g.redirectGitHubAppOAuthResult(w, r, state.ReturnTo, "success")
+}
+
+func (g *gatewayService) buildGitHubAppInstallURL() (string, error) {
+	slug := strings.TrimSpace(g.githubAppSlug)
+	if slug == "" {
+		return "", errors.New("github app slug is required")
+	}
+	if !isValidGitHubAppSlug(slug) {
+		return "", errors.New("github app slug is invalid")
+	}
+	return fmt.Sprintf(githubAppInstallURLFormat, slug), nil
+}
+
+func isValidGitHubAppSlug(slug string) bool {
+	for _, r := range slug {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func parseRequiredUint32(r *http.Request, name string) (uint32, error) {

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -132,6 +132,9 @@ func (g *gatewayService) buildGitHubAppInstallURL() (string, error) {
 }
 
 func isValidGitHubAppSlug(slug string) bool {
+	if slug == "" {
+		return false
+	}
 	for _, r := range slug {
 		if r >= 'a' && r <= 'z' {
 			continue

--- a/service_code_github_app.go
+++ b/service_code_github_app.go
@@ -139,9 +139,6 @@ func isValidGitHubAppSlug(slug string) bool {
 		if r >= 'a' && r <= 'z' {
 			continue
 		}
-		if r >= 'A' && r <= 'Z' {
-			continue
-		}
 		if r >= '0' && r <= '9' {
 			continue
 		}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -150,6 +150,28 @@ func TestBuildGitHubAppInstallURLRejectsInvalidSlug(t *testing.T) {
 	}
 }
 
+func TestIsValidGitHubAppSlug(t *testing.T) {
+	cases := []struct {
+		name string
+		slug string
+		want bool
+	}{
+		{name: "lowercase", slug: "codescan-app-test", want: true},
+		{name: "uppercase", slug: "CodeScan-App-Test", want: true},
+		{name: "number", slug: "codescan-app-1", want: true},
+		{name: "empty", want: false},
+		{name: "path", slug: "owner/app", want: false},
+		{name: "query", slug: "app?state=value", want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isValidGitHubAppSlug(c.slug); got != c.want {
+				t.Fatalf("Unexpected result. want=%t, got=%t", c.want, got)
+			}
+		})
+	}
+}
+
 func TestBuildGitHubAppOAuthStartURLAllowsLocalHTTPRedirectURL(t *testing.T) {
 	svc := &gatewayService{
 		envName:              "local",

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -115,6 +115,41 @@ func TestBuildGitHubAppOAuthStartURL(t *testing.T) {
 	}
 }
 
+func TestBuildGitHubAppInstallURL(t *testing.T) {
+	svc := &gatewayService{githubAppSlug: "codescan-app-test"}
+	got, err := svc.buildGitHubAppInstallURL()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "https://github.com/apps/codescan-app-test/installations/select_target" {
+		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
+func TestBuildGitHubAppInstallURLRejectsInvalidSlug(t *testing.T) {
+	cases := []struct {
+		name string
+		slug string
+	}{
+		{name: "empty"},
+		{name: "blank", slug: "   "},
+		{name: "path", slug: "owner/app"},
+		{name: "query", slug: "app?state=value"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := &gatewayService{githubAppSlug: c.slug}
+			_, err := svc.buildGitHubAppInstallURL()
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatal("Expected non-empty error")
+			}
+		})
+	}
+}
+
 func TestBuildGitHubAppOAuthStartURLAllowsLocalHTTPRedirectURL(t *testing.T) {
 	svc := &gatewayService{
 		envName:              "local",

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -157,11 +157,13 @@ func TestIsValidGitHubAppSlug(t *testing.T) {
 		want bool
 	}{
 		{name: "lowercase", slug: "codescan-app-test", want: true},
-		{name: "uppercase", slug: "CodeScan-App-Test", want: true},
 		{name: "number", slug: "codescan-app-1", want: true},
 		{name: "empty", want: false},
+		{name: "uppercase", slug: "CodeScan-App-Test", want: false},
 		{name: "path", slug: "owner/app", want: false},
 		{name: "query", slug: "app?state=value", want: false},
+		{name: "at sign", slug: "app@example", want: false},
+		{name: "plus", slug: "app+test", want: false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## PRの概要

管理者がGitHub Appを事前インストールする方式に合わせて、gatewayからGitHub Appのインストール先選択画面へ遷移するためのURLを返せるようにします。

`GITHUB_APP_SLUG` から `https://github.com/apps/{slug}/installations/select_target` を生成するendpointを追加し、設定者のUser-to-Server OAuthで使う `state` や `redirect_uri` とは責務を分けます。

## 背景

GitHub App の事前インストール導線をWebから開始できるようにするためです。

既存のUser-to-Server OAuth導線とは別に、管理者がGitHub Appのインストール先を選ぶためのURLが必要になりました。

## 全体のタスクにおける本PRの立ち位置
```mermaid
flowchart TD
    A["RISKEN管理者<br/>GitHub Appを用意する"] --> B["Org管理者<br/>GitHub上でRISKEN Appを許可する"]
    B --> C["RISKEN利用者<br/>コードスキャン設定を作る"]
    C --> D["RISKEN<br/>GitHub側の許可内容を確認する"]
    D --> E["RISKEN<br/>設定者が対象Repositoryを扱えるか確認する"]
    E --> F["RISKEN<br/>定期的にコードスキャンを実行する"]

    A -.-> AStatus["運用作業<br/>実装対象外"]
    B -.-> BStatus["今回PR<br/>backend入口を追加"]
    C -.-> CStatus["実装済み"]
    D -.-> DStatus["実装済み"]
    E -.-> EStatus["backend実装済み<br/>frontend導線は後続"]
    F -.-> FStatus["実装済み"]

    B:::current
    BStatus:::current
    classDef current fill:#fff3cd,stroke:#d39e00,stroke-width:2px,color:#24292f;
    classDef status fill:#f8f9fa,stroke:#adb5bd,stroke-width:1px,color:#24292f;
    class AStatus,CStatus,DStatus,EStatus,FStatus status;
```

## 修正点

| 変更点 | 内容 |
|---|---|
| 設定追加 | `GITHUB_APP_SLUG` を gateway の設定値として追加 |
| endpoint追加 | `GET /api/v1/code/github-app/install-url` を追加し、GitHub App install URL を返却 |
| URL生成 | slug から `https://github.com/apps/{slug}/installations/select_target` を生成 |
| 入力検証 | slug が空、パス区切り、query を含む場合は不正値として拒否 |
| テスト追加 | install URL生成、slug validation、gateway config validation のテストを追加 |

```mermaid
sequenceDiagram
    participant Admin as Org管理者
    participant Web as RISKEN Web
    participant Gateway as Gateway
    participant GitHub as GitHub

    Admin->>Web: GitHub Appインストールを開始
    Web->>Gateway: GET /api/v1/code/github-app/install-url
    Gateway-->>Web: GitHub App install URL
    Web-->>Admin: GitHubへ遷移
    Admin->>GitHub: AppをOrg/UserにインストールしRepositoryを選択
    GitHub-->>Admin: インストール完了
```

## 重点レビューポイント

- App install URL endpoint がOAuth stateやredirect_uriを扱わず、管理者向けインストール導線として責務分離されているかどうか
- `GITHUB_APP_SLUG` が未設定でも既存gateway起動や既存OAuth導線に影響しないかどうか
- slugにパス区切りやqueryを含む不正値を拒否し、意図しないGitHub URLを生成しないかどうか

## 動作確認

現在のPRブランチのgatewayを `risken-gateway:local` としてbuildし、local Kubernetes の gateway Deploymentをrollout restartしました。

`GITHUB_APP_SLUG=codescan-app-test` が入っている状態で、以下のendpointがGitHub App install target selection URLを返すことを確認しました。

```http
GET /api/v1/code/github-app/install-url?project_id=1001
HTTP/1.1 200 OK

{"data":{"url":"https://github.com/apps/codescan-app-test/installations/select_target"}}
```

ブラウザ確認では、以下のURLを開いてGitHub側の「どのOrg/UserにこのAppをインストールするか」を選ぶ画面へ遷移することを確認します。

[GitHub App install target selection](https://github.com/apps/codescan-app-test/installations/select_target)

この導線ではOAuth callbackは発生しません。
