### PR TITLE
Add GitHub App installation status gateway route

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260703055418-66be65b3ccce
+	github.com/ca-risken/datasource-api v0.16.1-0.20260707054244-80eda948c426
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d
 	github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42
-	github.com/ca-risken/datasource-api v0.16.1-0.20260629092252-84670740cab7
+	github.com/ca-risken/datasource-api v0.16.1-0.20260703055418-66be65b3ccce
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260703055418-66be65b3ccce h1:pe/LxJDDBWG6CJq0m6LKbkJEh3+SoqOs18WHtAnIIHs=
-github.com/ca-risken/datasource-api v0.16.1-0.20260703055418-66be65b3ccce/go.mod h1:HtB67lg18k0n3hhCgxfz9qYPQUPWjprArcpCDlig4fM=
+github.com/ca-risken/datasource-api v0.16.1-0.20260707054244-80eda948c426 h1:IsELcADi9Z8dd9mM/7uMJ6qQIjn1ssNKrbVYkzcsET8=
+github.com/ca-risken/datasource-api v0.16.1-0.20260707054244-80eda948c426/go.mod h1:HtB67lg18k0n3hhCgxfz9qYPQUPWjprArcpCDlig4fM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d h1:d+Q
 github.com/ca-risken/common/pkg/tracer v0.0.0-20230727031236-b35703d5c59d/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42 h1:0YEP1pyMjUVUKZZorgP5zXuOszW/gzaZS57XmvceMIw=
 github.com/ca-risken/core v0.16.1-0.20260414074006-9c3094ff3f42/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260629092252-84670740cab7 h1:qxIobowqOjUX3k6ZduLolubn4C1VcVAxfcXNdtFZdXY=
-github.com/ca-risken/datasource-api v0.16.1-0.20260629092252-84670740cab7/go.mod h1:HtB67lg18k0n3hhCgxfz9qYPQUPWjprArcpCDlig4fM=
+github.com/ca-risken/datasource-api v0.16.1-0.20260703055418-66be65b3ccce h1:pe/LxJDDBWG6CJq0m6LKbkJEh3+SoqOs18WHtAnIIHs=
+github.com/ca-risken/datasource-api v0.16.1-0.20260703055418-66be65b3ccce/go.mod h1:HtB67lg18k0n3hhCgxfz9qYPQUPWjprArcpCDlig4fM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/hack/protoc-gen-service.yml
+++ b/hack/protoc-gen-service.yml
@@ -39,6 +39,7 @@ excludes:
   - DataSourceService.NotifyScanError
   - CodeService.GetGitleaksCache
   - CodeService.PutGitleaksCache
+  - CodeService.VerifyGitHubAppUser
   - CodeService.ListCodescanTargetRepository
   - CodeService.PutGitleaksRepository
   - CodeService.PutDependencyRepository

--- a/router.go
+++ b/router.go
@@ -330,6 +330,7 @@ func newRouter(svc *gatewayService) *chi.Mux {
 				r.Use(svc.authzWithProject)
 				r.Get("/list-github-setting", svc.listGitHubSettingCodeHandler)
 				r.Get("/list-gitleaks-cache", svc.listGitleaksCacheCodeHandler)
+				r.Get("/github-app/installation-status", svc.getGitHubAppInstallationStatusCodeHandler)
 				r.Get("/github-app/install-url", svc.githubAppInstallURLHandler)
 				r.Get("/github-app/oauth-start", svc.githubAppOAuthStartHandler)
 				r.Group(func(r chi.Router) {

--- a/service_code_generated.go
+++ b/service_code_generated.go
@@ -72,6 +72,27 @@ func (g *gatewayService) putGitHubSettingCodeHandler(w http.ResponseWriter, r *h
 	writeResponse(ctx, w, http.StatusOK, map[string]interface{}{successJSONKey: resp})
 }
 
+func (g *gatewayService) getGitHubAppInstallationStatusCodeHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	req := &code.GetGitHubAppInstallationStatusRequest{}
+	if err := bind(req, r); err != nil {
+		appLogger.Warnf(ctx, "Failed to bind request, req=%s, err=%+v", "GetGitHubAppInstallationStatusRequest", err)
+	}
+	if err := req.Validate(); err != nil {
+		writeResponse(ctx, w, http.StatusBadRequest, map[string]interface{}{errorJSONKey: err.Error()})
+		return
+	}
+	resp, err := g.codeClient.GetGitHubAppInstallationStatus(ctx, req)
+	if err != nil {
+		if handleErr := handleGRPCError(ctx, w, err); handleErr != nil {
+			appLogger.Errorf(ctx, "HandleGRPCError: %+v", handleErr)
+			writeResponse(ctx, w, http.StatusInternalServerError, map[string]interface{}{errorJSONKey: "InternalServerError"})
+		}
+		return
+	}
+	writeResponse(ctx, w, http.StatusOK, map[string]interface{}{successJSONKey: resp})
+}
+
 func (g *gatewayService) verifyGitHubAppInstallationCodeHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	req := &code.VerifyGitHubAppInstallationRequest{}

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/ca-risken/core/proto/iam"
 	iammocks "github.com/ca-risken/core/proto/iam/mocks"
+	"github.com/ca-risken/datasource-api/proto/code"
+	codemocks "github.com/ca-risken/datasource-api/proto/code/mocks"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -123,6 +126,42 @@ func TestBuildGitHubAppInstallURL(t *testing.T) {
 	}
 	if got != "https://github.com/apps/codescan-app-test/installations/select_target" {
 		t.Fatalf("Unexpected URL: %s", got)
+	}
+}
+
+func TestGetGitHubAppInstallationStatusCodeHandler(t *testing.T) {
+	codeMock := codemocks.NewCodeServiceClient(t)
+	svc := &gatewayService{codeClient: codeMock}
+	codeMock.On("GetGitHubAppInstallationStatus", mock.Anything, mock.MatchedBy(func(req *code.GetGitHubAppInstallationStatusRequest) bool {
+		return req.ProjectId == 1001 &&
+			req.Type == code.Type_ORGANIZATION &&
+			req.BaseUrl == "https://api.github.com/" &&
+			req.TargetResource == "ca-risken"
+	})).Return(&code.GetGitHubAppInstallationStatusResponse{
+		GithubAppInstallationStatus: &code.GitHubAppInstallationStatus{
+			TargetResource:      "ca-risken",
+			Installed:           true,
+			RepositorySelection: "selected",
+			RepositoryCount:     3,
+			Reason:              code.GitHubAppInstallationReasonInstalled,
+		},
+	}, nil).Once()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/installation-status?project_id=1001&type=1&base_url=https%3A%2F%2Fapi.github.com%2F&target_resource=ca-risken", nil)
+
+	svc.getGitHubAppInstallationStatusCodeHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Unexpected status. want=%d, got=%d", http.StatusOK, rec.Code)
+	}
+	resp := map[string]*code.GetGitHubAppInstallationStatusResponse{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Unexpected json decode error: %v", err)
+	}
+	status := resp[successJSONKey].GetGithubAppInstallationStatus()
+	if !status.GetInstalled() || status.GetTargetResource() != "ca-risken" || status.GetRepositoryCount() != 3 {
+		t.Fatalf("Unexpected installation status: %+v", status)
 	}
 }
 

--- a/service_code_github_app_test.go
+++ b/service_code_github_app_test.go
@@ -134,21 +134,18 @@ func TestGetGitHubAppInstallationStatusCodeHandler(t *testing.T) {
 	svc := &gatewayService{codeClient: codeMock}
 	codeMock.On("GetGitHubAppInstallationStatus", mock.Anything, mock.MatchedBy(func(req *code.GetGitHubAppInstallationStatusRequest) bool {
 		return req.ProjectId == 1001 &&
-			req.Type == code.Type_ORGANIZATION &&
-			req.BaseUrl == "https://api.github.com/" &&
-			req.TargetResource == "ca-risken"
+			req.GithubSettingId == 1017
 	})).Return(&code.GetGitHubAppInstallationStatusResponse{
 		GithubAppInstallationStatus: &code.GitHubAppInstallationStatus{
 			TargetResource:      "ca-risken",
 			Installed:           true,
 			RepositorySelection: "selected",
-			RepositoryCount:     3,
 			Reason:              code.GitHubAppInstallationReasonInstalled,
 		},
 	}, nil).Once()
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/installation-status?project_id=1001&type=1&base_url=https%3A%2F%2Fapi.github.com%2F&target_resource=ca-risken", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/code/github-app/installation-status?project_id=1001&github_setting_id=1017", nil)
 
 	svc.getGitHubAppInstallationStatusCodeHandler(rec, req)
 
@@ -160,7 +157,7 @@ func TestGetGitHubAppInstallationStatusCodeHandler(t *testing.T) {
 		t.Fatalf("Unexpected json decode error: %v", err)
 	}
 	status := resp[successJSONKey].GetGithubAppInstallationStatus()
-	if !status.GetInstalled() || status.GetTargetResource() != "ca-risken" || status.GetRepositoryCount() != 3 {
+	if !status.GetInstalled() || status.GetTargetResource() != "ca-risken" {
 		t.Fatalf("Unexpected installation status: %+v", status)
 	}
 }


### PR DESCRIPTION
## PRの概要

GitHub設定保存後にWebからGitHub Appのインストール状態を確認できるようにするため、Gateway側でdatasource-apiの最新RPC契約に追従します。

これにより、Webは保存済みGitHub設定の `project_id` と `github_setting_id` を使ってGatewayへ問い合わせ、Gatewayはproject認可を通したうえでdatasource-apiへ状態確認を委譲できるようになります。

## 背景

### 【目的】

GitHub設定保存後に、WebからGitHub Appのインストール状態を確認できるようにすることが目的です。

未インストールの場合はWeb側で警告を表示し、設定者がGitHub Appのインストール状況を把握できるようにします。

### 【経緯】

datasource-api側では、[ca-risken/datasource-api#122](https://github.com/ca-risken/datasource-api/pull/122) により、GitHub Appのインストール状態確認RPCが `project_id` と `github_setting_id` を受け取る契約に更新されています。

そのため、Gateway側でもdatasource-apiの最新RPC契約に追従しないと、Webからの保存後確認が動作しません。

### 【経緯を踏まえた方針】

Gatewayでは `github-app/installation-status` を `authzWithProject` 配下に置き、project認可後にdatasource-apiへ委譲します。

保存後確認の用途に合わせ、WebやGatewayから `target_resource` を直接渡すのではなく、保存済みの `github_setting_id` を基準にdatasource-api側で対象GitHub設定を解決する方針にします。

## 修正点

| 変更点 | 内容 |
|---|---|
| datasource-api依存更新 | `GetGitHubAppInstallationStatus` の最新RPC契約を参照するよう更新 |
| Gateway route | `github-app/installation-status` を `authzWithProject` 配下で利用する構成を維持 |
| テスト修正 | `project_id` と `github_setting_id` がRPC requestへ渡ることを確認 |
| レスポンス確認 | 最新RPCから返るインストール状態レスポンスに合わせてテスト期待値を更新 |

```mermaid
sequenceDiagram
    actor User as RISKEN利用者
    participant Web as Web
    participant Gateway as Gateway
    participant DS as datasource-api
    participant GitHub as GitHub API

    User->>Web: GitHub App設定を保存
    Web->>Gateway: PutGitHubSetting
    Gateway->>DS: GitHub設定を保存
    DS-->>Gateway: 保存済みGitHub設定
    Gateway-->>Web: 保存結果

    Web->>Gateway: GetGitHubAppInstallationStatus(project_id, github_setting_id)
    rect rgb(255, 243, 205)
        Note over Gateway: 今回PR<br/>project認可済みrouteと最新RPC依存を反映
        Gateway->>Gateway: authzWithProjectでproject認可
        Gateway->>DS: GetGitHubAppInstallationStatus(project_id, github_setting_id)
    end
    DS->>DS: project_idとgithub_setting_idの対応を確認
    DS->>GitHub: GitHub App installationを確認
    GitHub-->>DS: installed / reason
    DS-->>Gateway: インストール状態
    Gateway-->>Web: 表示用レスポンス
    Web-->>User: インストール済み/未インストールを表示
```

## 重点レビューポイント

- Gateway側のAPIが `authzWithProject` 配下にあり、project認可後にdatasource-apiへ委譲されているかどうか。
- 保存後確認の用途に合わせて、`target_resource` ではなく `github_setting_id` を使う契約になっているかどうか。
- datasource-api側にGitHub設定の解決責務を寄せ、Gateway側がGitHub設定の詳細を持ちすぎていないかどうか。

## 動作確認

`go test ./...` を実行し、gateway全体のGoテストが成功することを確認しました。

ローカルKubernetes上でgateway、datasource-api、webを最新化し、WebのGitHub設定保存後にインストール状態確認APIが呼ばれることを確認しました。
