### PR TITLE
chore: Refresh*SettingStatus を gateway 生成対象から除外する

### DIFF
--- a/hack/protoc-gen-service.yml
+++ b/hack/protoc-gen-service.yml
@@ -44,6 +44,9 @@ excludes:
   - CodeService.PutGitleaksRepository
   - CodeService.PutDependencyRepository
   - CodeService.PutCodeScanRepository
+  - CodeService.RefreshGitleaksSettingStatus
+  - CodeService.RefreshDependencySettingStatus
+  - CodeService.RefreshCodeScanSettingStatus
   # Ignore for customized proxy
   - IAMService.PutUser
   - IAMService.AuthenticateAccessToken


### PR DESCRIPTION
## PRの概要

datasource-api に追加する親ステータス再計算 RPC（https://github.com/ca-risken/datasource-api/pull/125）は code ワーカー内部向けのため、gateway の自動生成対象から除外します。

## レビュー観点例

- [ ] Put*Repository と同様に worker 内部 RPC として除外するのが妥当な点
- [ ] Web UI から親再計算を公開しない方針と一致している点


Made with [Cursor](https://cursor.com)